### PR TITLE
Refine TabButton and add component tests

### DIFF
--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,7 +1,0 @@
-import React from 'react';
-import { render, screen } from '@testing-library/react';
-
-test('renders a placeholder title', () => {
-  render(<div>Merchant's Morning</div>);
-  expect(screen.getByText(/Merchant's Morning/i)).toBeInTheDocument();
-});

--- a/src/components/TabButton.jsx
+++ b/src/components/TabButton.jsx
@@ -5,7 +5,8 @@ const TabButton = ({ active, onClick, children, count }) => (
     onClick={onClick}
     className={`px-3 py-1 rounded-md text-sm font-bold ${active ? 'bg-blue-500 text-white' : 'bg-gray-200 text-gray-700'}`}
   >
-    {children} {count && `(${count})`}
+    {children}
+    {count !== undefined && count !== null && ` (${count})`}
   </button>
 );
 

--- a/src/components/__tests__/EventLog.test.jsx
+++ b/src/components/__tests__/EventLog.test.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import EventLog from '../EventLog.jsx';
+
+describe('EventLog', () => {
+  test('renders placeholder when no events', () => {
+    render(<EventLog events={[]} />);
+    expect(screen.getByText(/No events yet/i)).toBeInTheDocument();
+  });
+
+  test('renders event entries', () => {
+    const events = [
+      { id: 1, message: 'Test event', type: 'info', timestamp: '10:00' }
+    ];
+    render(<EventLog events={events} />);
+    expect(screen.getByText('Test event')).toBeInTheDocument();
+    expect(screen.getByText('10:00')).toBeInTheDocument();
+  });
+});

--- a/src/components/__tests__/Notifications.test.jsx
+++ b/src/components/__tests__/Notifications.test.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import Notifications from '../Notifications.jsx';
+
+describe('Notifications', () => {
+  test('renders notifications', () => {
+    const notifications = [
+      { id: 1, message: 'Hello', type: 'success' },
+      { id: 2, message: 'Error', type: 'error' }
+    ];
+    render(<Notifications notifications={notifications} />);
+    expect(screen.getByText('Hello')).toBeInTheDocument();
+    expect(screen.getByText('Error')).toBeInTheDocument();
+  });
+});

--- a/src/components/__tests__/TabButton.test.jsx
+++ b/src/components/__tests__/TabButton.test.jsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import TabButton from '../TabButton.jsx';
+
+describe('TabButton', () => {
+  test('shows count even when zero', () => {
+    render(
+      <TabButton active={false} onClick={() => {}} count={0}>
+        Weapons
+      </TabButton>
+    );
+    expect(screen.getByRole('button')).toHaveTextContent('Weapons (0)');
+  });
+
+  test('hides count when not provided', () => {
+    render(
+      <TabButton active={false} onClick={() => {}}>
+        Armor
+      </TabButton>
+    );
+    const button = screen.getByRole('button');
+    expect(button).toHaveTextContent('Armor');
+    expect(button).not.toHaveTextContent(/\(/);
+  });
+});


### PR DESCRIPTION
## Summary
- Ensure `TabButton` displays counts even when zero
- Add tests for `TabButton`, `EventLog`, and `Notifications` components
- Remove placeholder App test

## Testing
- `CI=true npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68909cc3cbb88320bdcf96503d63a882