### PR TITLE
fix: correct PWA asset paths

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -8,7 +8,7 @@
     <meta name="description" content="A fantasy shopkeeping game where you craft items and serve customers" />
     
     <!-- PWA Meta Tags -->
-    <link rel="apple-touch-icon" href="%PUBLIC_URL%/icon-192.png" />
+    <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
     
     <!-- CRITICAL: Tailwind CSS - Make sure this loads FIRST -->
@@ -78,7 +78,7 @@
     <script>
       if ('serviceWorker' in navigator) {
         window.addEventListener('load', () => {
-          navigator.serviceWorker.register('%PUBLIC_URL%/sw.js')
+          navigator.serviceWorker.register('%PUBLIC_URL%/service-worker.js')
             .then((registration) => {
               console.log('SW registered: ', registration);
             })


### PR DESCRIPTION
## Summary
- use existing icon for Apple touch icon tag
- point service worker registration to generated `service-worker.js`

## Testing
- `CI=true npm test --silent`
- `npm run build --silent`


------
https://chatgpt.com/codex/tasks/task_e_6890d50748a48320bf88e8f84a3487c3