### PR TITLE
Persist state and add deterministic RNG

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -28,6 +28,23 @@ const MerchantsMorning = () => {
     shopLevel: 1
   });
 
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const savedState = window.localStorage.getItem('gameState');
+    if (savedState) {
+      try {
+        setGameState(JSON.parse(savedState));
+      } catch (e) {
+        console.error('Failed to load game state', e);
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    window.localStorage.setItem('gameState', JSON.stringify(gameState));
+  }, [gameState]);
+
   const [eventLog, setEventLog] = useState([]);
   const [notifications, setNotifications] = useState([]);
   const [selectedCustomer, setSelectedCustomer] = useState(null);
@@ -44,7 +61,7 @@ const MerchantsMorning = () => {
 
   const addEvent = (message, type = 'info') => {
     const event = {
-      id: Date.now(),
+        id: crypto.randomUUID(),
       message,
       type,
       timestamp: new Date().toLocaleTimeString()
@@ -54,7 +71,7 @@ const MerchantsMorning = () => {
 
   const addNotification = (message, type = 'success') => {
     const notification = {
-      id: Date.now(),
+        id: crypto.randomUUID(),
       message,
       type
     };

--- a/src/hooks/__tests__/gameLogic.test.js
+++ b/src/hooks/__tests__/gameLogic.test.js
@@ -1,0 +1,51 @@
+import useCrafting from '../useCrafting';
+import useCustomers from '../useCustomers';
+import { setSeed } from '../../utils/random';
+import { PHASES } from '../../constants';
+
+describe('core game logic', () => {
+  test('openBox charges gold and yields deterministic materials', () => {
+    let state1 = { gold: 100, materials: {}, inventory: {}, phase: PHASES.MORNING };
+    const setState1 = (fn) => { state1 = typeof fn === 'function' ? fn(state1) : fn; };
+    const { openBox } = useCrafting(state1, setState1, jest.fn(), jest.fn());
+
+    setSeed(123);
+    openBox('bronze');
+
+    expect(state1.gold).toBe(80);
+    const materialsAfter = { ...state1.materials };
+
+    let state2 = { gold: 100, materials: {}, inventory: {}, phase: PHASES.MORNING };
+    const setState2 = (fn) => { state2 = typeof fn === 'function' ? fn(state2) : fn; };
+    const { openBox: openBox2 } = useCrafting(state2, setState2, jest.fn(), jest.fn());
+
+    setSeed(123);
+    openBox2('bronze');
+
+    expect(state2.gold).toBe(80);
+    expect(state2.materials).toEqual(materialsAfter);
+  });
+
+  test('craftItem consumes materials and adds to inventory', () => {
+    let state = { materials: { iron: 2, wood: 1 }, inventory: {}, gold: 0, phase: PHASES.CRAFTING };
+    const setState = (fn) => { state = typeof fn === 'function' ? fn(state) : fn; };
+    const { craftItem } = useCrafting(state, setState, jest.fn(), jest.fn());
+
+    craftItem('iron_dagger');
+
+    expect(state.materials).toEqual({ iron: 1, wood: 0 });
+    expect(state.inventory.iron_dagger).toBe(1);
+  });
+
+  test('startNewDay resets customers and increments day', () => {
+    let state = { phase: PHASES.END_DAY, day: 1, customers: [{ id: '1' }], inventory: {}, gold: 0, totalEarnings: 0 };
+    const setState = (fn) => { state = typeof fn === 'function' ? fn(state) : fn; };
+    const { startNewDay } = useCustomers(state, setState, jest.fn(), jest.fn(), jest.fn());
+
+    startNewDay();
+
+    expect(state.day).toBe(2);
+    expect(state.phase).toBe(PHASES.MORNING);
+    expect(state.customers).toEqual([]);
+  });
+});

--- a/src/hooks/useCrafting.js
+++ b/src/hooks/useCrafting.js
@@ -1,14 +1,15 @@
 import { MATERIALS, RECIPES, BOX_TYPES, RARITY_ORDER } from '../constants';
+import { random } from '../utils/random';
 
 const useCrafting = (gameState, setGameState, addEvent, addNotification) => {
   const getRandomMaterial = (rarityWeights) => {
-    const rand = Math.random() * 100;
+    const rand = random() * 100;
     let threshold = 0;
     for (const [rarity, weight] of Object.entries(rarityWeights)) {
       threshold += weight;
       if (rand <= threshold) {
         const materialsOfRarity = Object.entries(MATERIALS).filter(([, mat]) => mat.rarity === rarity);
-        const randomMat = materialsOfRarity[Math.floor(Math.random() * materialsOfRarity.length)];
+        const randomMat = materialsOfRarity[Math.floor(random() * materialsOfRarity.length)];
         return randomMat[0];
       }
     }
@@ -21,7 +22,7 @@ const useCrafting = (gameState, setGameState, addEvent, addNotification) => {
       addNotification('Not enough gold!', 'error');
       return;
     }
-    const materialCount = Math.floor(Math.random() * (box.materialCount[1] - box.materialCount[0] + 1)) + box.materialCount[0];
+    const materialCount = Math.floor(random() * (box.materialCount[1] - box.materialCount[0] + 1)) + box.materialCount[0];
     const newMaterials = { ...gameState.materials };
     const foundMaterials = [];
     for (let i = 0; i < materialCount; i++) {

--- a/src/hooks/useCustomers.js
+++ b/src/hooks/useCustomers.js
@@ -1,8 +1,9 @@
 import { PHASES, RECIPES } from '../constants';
+import { random } from '../utils/random';
 
 const useCustomers = (gameState, setGameState, addEvent, addNotification, setSelectedCustomer) => {
   const generateCustomers = () => {
-    const customerCount = Math.floor(Math.random() * 4) + 3;
+    const customerCount = Math.floor(random() * 4) + 3;
     const customers = [];
 
     const getRarityWeights = (day) => {
@@ -16,7 +17,7 @@ const useCustomers = (gameState, setGameState, addEvent, addNotification, setSel
     };
 
     const getRandomRarity = (weights) => {
-      const rand = Math.random() * 100;
+      const rand = random() * 100;
       let threshold = 0;
       for (const [rarity, weight] of Object.entries(weights)) {
         threshold += weight;
@@ -29,23 +30,23 @@ const useCustomers = (gameState, setGameState, addEvent, addNotification, setSel
       const requests = ['weapon', 'armor', 'trinket'];
       const rarityWeights = getRarityWeights(gameState.day);
 
-      const requestType = requests[Math.floor(Math.random() * requests.length)];
+      const requestType = requests[Math.floor(random() * requests.length)];
       const requestRarity = getRandomRarity(rarityWeights);
       const basePrice = requestRarity === 'common' ? 15 : requestRarity === 'uncommon' ? 25 : 50;
-      const offerPrice = Math.floor(basePrice * (0.9 + Math.random() * 0.3));
+      const offerPrice = Math.floor(basePrice * (0.9 + random() * 0.3));
 
-      const flexibility = Math.random();
+      const flexibility = random();
       const isFlexible = flexibility > 0.6;
 
       customers.push({
-        id: i,
+        id: crypto.randomUUID(),
         name: `Customer ${i + 1}`,
         requestType,
         requestRarity,
         offerPrice,
         satisfied: false,
         isFlexible,
-        patience: Math.floor(Math.random() * 3) + 2
+        patience: Math.floor(random() * 3) + 2
       });
     }
 

--- a/src/utils/random.js
+++ b/src/utils/random.js
@@ -1,0 +1,18 @@
+let seeded = false;
+let state = 1;
+
+export const setSeed = (s) => {
+  if (typeof s !== 'number') {
+    seeded = false;
+    return;
+  }
+  seeded = true;
+  state = s % 2147483647;
+  if (state <= 0) state += 2147483646;
+};
+
+export const random = () => {
+  if (!seeded) return Math.random();
+  state = (state * 16807) % 2147483647;
+  return (state - 1) / 2147483646;
+};


### PR DESCRIPTION
## Summary
- persist `gameState` to localStorage on load/save
- introduce seedable RNG utility and switch game logic to use it
- generate unique identifiers with `crypto.randomUUID`
- cover core logic with unit tests for boxes, crafting, and new days

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_689113419e1883208f5ea224252709de