### PR TITLE
Add reset game and refactor persistence

### DIFF
--- a/src/constants/boxes.js
+++ b/src/constants/boxes.js
@@ -1,0 +1,5 @@
+export const BOX_TYPES = {
+  bronze: { name: 'Bronze Box', cost: 20, materialCount: [5, 7], rarityWeights: { common: 75, uncommon: 25, rare: 0 } },
+  silver: { name: 'Silver Box', cost: 45, materialCount: [6, 9], rarityWeights: { common: 45, uncommon: 45, rare: 10 } },
+  gold: { name: 'Gold Box', cost: 85, materialCount: [7, 10], rarityWeights: { common: 25, uncommon: 55, rare: 20 } },
+};

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -1,0 +1,6 @@
+export * from './phases';
+export * from './materials';
+export * from './recipes';
+export * from './boxes';
+export * from './items';
+

--- a/src/constants/items.js
+++ b/src/constants/items.js
@@ -1,0 +1,3 @@
+export const ITEM_TYPES = ['weapon', 'armor', 'trinket'];
+export const RARITY_ORDER = { rare: 3, uncommon: 2, common: 1 };
+

--- a/src/constants/materials.js
+++ b/src/constants/materials.js
@@ -1,0 +1,18 @@
+export const MATERIALS = {
+  iron: { name: 'Iron', rarity: 'common', icon: '⚙️' },
+  wood: { name: 'Wood', rarity: 'common', icon: '🪵' },
+  fur: { name: 'Fur', rarity: 'common', icon: '🦫' },
+  cloth: { name: 'Cloth', rarity: 'common', icon: '🧵' },
+  stone: { name: 'Stone', rarity: 'common', icon: '🪨' },
+  bone: { name: 'Bone', rarity: 'common', icon: '🦴' },
+  leather: { name: 'Leather', rarity: 'uncommon', icon: '🪖' },
+  silver_ore: { name: 'Silver Ore', rarity: 'uncommon', icon: '🥈' },
+  silk: { name: 'Silk', rarity: 'uncommon', icon: '🕸️' },
+  bronze: { name: 'Bronze', rarity: 'uncommon', icon: '🔶' },
+  gemstone: { name: 'Gemstone', rarity: 'rare', icon: '💎' },
+  gold_ore: { name: 'Gold Ore', rarity: 'rare', icon: '✨' },
+  crystal: { name: 'Crystal', rarity: 'rare', icon: '🔮' },
+  mithril: { name: 'Mithril', rarity: 'rare', icon: '⚡' },
+  ruby: { name: 'Ruby', rarity: 'rare', icon: '♦️' },
+  obsidian: { name: 'Obsidian', rarity: 'rare', icon: '⬛' },
+};

--- a/src/constants/phases.js
+++ b/src/constants/phases.js
@@ -1,0 +1,6 @@
+export const PHASES = {
+  MORNING: 'morning',
+  CRAFTING: 'crafting',
+  SHOPPING: 'shopping',
+  END_DAY: 'end_day',
+};

--- a/src/constants/recipes.js
+++ b/src/constants/recipes.js
@@ -1,29 +1,3 @@
-export const PHASES = {
-  MORNING: 'morning',
-  CRAFTING: 'crafting',
-  SHOPPING: 'shopping',
-  END_DAY: 'end_day',
-};
-
-export const MATERIALS = {
-  iron: { name: 'Iron', rarity: 'common', icon: '⚙️' },
-  wood: { name: 'Wood', rarity: 'common', icon: '🪵' },
-  fur: { name: 'Fur', rarity: 'common', icon: '🦫' },
-  cloth: { name: 'Cloth', rarity: 'common', icon: '🧵' },
-  stone: { name: 'Stone', rarity: 'common', icon: '🪨' },
-  bone: { name: 'Bone', rarity: 'common', icon: '🦴' },
-  leather: { name: 'Leather', rarity: 'uncommon', icon: '🪖' },
-  silver_ore: { name: 'Silver Ore', rarity: 'uncommon', icon: '🥈' },
-  silk: { name: 'Silk', rarity: 'uncommon', icon: '🕸️' },
-  bronze: { name: 'Bronze', rarity: 'uncommon', icon: '🔶' },
-  gemstone: { name: 'Gemstone', rarity: 'rare', icon: '💎' },
-  gold_ore: { name: 'Gold Ore', rarity: 'rare', icon: '✨' },
-  crystal: { name: 'Crystal', rarity: 'rare', icon: '🔮' },
-  mithril: { name: 'Mithril', rarity: 'rare', icon: '⚡' },
-  ruby: { name: 'Ruby', rarity: 'rare', icon: '♦️' },
-  obsidian: { name: 'Obsidian', rarity: 'rare', icon: '⬛' },
-};
-
 export const RECIPES = [
   {
     id: 'iron_dagger',
@@ -242,13 +216,3 @@ export const RECIPES = [
     sellPrice: 72,
   },
 ];
-
-export const BOX_TYPES = {
-  bronze: { name: 'Bronze Box', cost: 20, materialCount: [5, 7], rarityWeights: { common: 75, uncommon: 25, rare: 0 } },
-  silver: { name: 'Silver Box', cost: 45, materialCount: [6, 9], rarityWeights: { common: 45, uncommon: 45, rare: 10 } },
-  gold: { name: 'Gold Box', cost: 85, materialCount: [7, 10], rarityWeights: { common: 25, uncommon: 55, rare: 20 } },
-};
-
-export const ITEM_TYPES = ['weapon', 'armor', 'trinket'];
-export const RARITY_ORDER = { rare: 3, uncommon: 2, common: 1 };
-

--- a/src/hooks/useCrafting.js
+++ b/src/hooks/useCrafting.js
@@ -18,25 +18,34 @@ const useCrafting = (gameState, setGameState, addEvent, addNotification) => {
 
   const openBox = (boxType) => {
     const box = BOX_TYPES[boxType];
-    if (gameState.gold < box.cost) {
+    let foundMaterials = [];
+    let materialCount = 0;
+    let insufficient = false;
+    setGameState(prev => {
+      if (prev.gold < box.cost) {
+        insufficient = true;
+        return prev;
+      }
+      materialCount = Math.floor(random() * (box.materialCount[1] - box.materialCount[0] + 1)) + box.materialCount[0];
+      const newMaterials = { ...prev.materials };
+      foundMaterials = [];
+      for (let i = 0; i < materialCount; i++) {
+        const material = getRandomMaterial(box.rarityWeights);
+        newMaterials[material] = (newMaterials[material] || 0) + 1;
+        foundMaterials.push(MATERIALS[material].name);
+      }
+      return {
+        ...prev,
+        gold: prev.gold - box.cost,
+        materials: newMaterials
+      };
+    });
+    if (insufficient) {
       addNotification('Not enough gold!', 'error');
-      return;
+    } else if (foundMaterials.length) {
+      addEvent(`Opened ${box.name}: Found ${foundMaterials.join(', ')}`, 'success');
+      addNotification(`📦 Opened ${box.name}! Found ${materialCount} materials`, 'success');
     }
-    const materialCount = Math.floor(random() * (box.materialCount[1] - box.materialCount[0] + 1)) + box.materialCount[0];
-    const newMaterials = { ...gameState.materials };
-    const foundMaterials = [];
-    for (let i = 0; i < materialCount; i++) {
-      const material = getRandomMaterial(box.rarityWeights);
-      newMaterials[material] = (newMaterials[material] || 0) + 1;
-      foundMaterials.push(MATERIALS[material].name);
-    }
-    setGameState(prev => ({
-      ...prev,
-      gold: prev.gold - box.cost,
-      materials: newMaterials
-    }));
-    addEvent(`Opened ${box.name}: Found ${foundMaterials.join(', ')}`, 'success');
-    addNotification(`📦 Opened ${box.name}! Found ${materialCount} materials`, 'success');
   };
 
   const craftItem = (recipeId) => {

--- a/src/hooks/usePersistentGameState.js
+++ b/src/hooks/usePersistentGameState.js
@@ -1,0 +1,55 @@
+import { useState, useEffect } from 'react';
+import { PHASES } from '../constants';
+
+const initialState = {
+  phase: PHASES.MORNING,
+  day: 1,
+  gold: 120,
+  materials: {
+    iron: 3,
+    wood: 3,
+    fur: 2,
+    cloth: 2,
+    stone: 2,
+    bone: 1,
+  },
+  inventory: {},
+  customers: [],
+  totalEarnings: 0,
+  shopLevel: 1,
+};
+
+export default function usePersistentGameState() {
+  const [gameState, setGameState] = useState(() => {
+    if (typeof window === 'undefined') return initialState;
+    try {
+      const saved = window.localStorage.getItem('gameState');
+      return saved ? JSON.parse(saved) : initialState;
+    } catch (e) {
+      console.error('Failed to load game state', e);
+      return initialState;
+    }
+  });
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    try {
+      window.localStorage.setItem('gameState', JSON.stringify(gameState));
+    } catch (e) {
+      console.error('Failed to save game state', e);
+    }
+  }, [gameState]);
+
+  const resetGame = () => {
+    setGameState(initialState);
+    if (typeof window !== 'undefined') {
+      try {
+        window.localStorage.removeItem('gameState');
+      } catch (e) {
+        console.error('Failed to reset game state', e);
+      }
+    }
+  };
+
+  return { gameState, setGameState, resetGame };
+}


### PR DESCRIPTION
## Summary
- add persistent game state hook with reset capability
- safeguard all localStorage reads and writes
- fix box opening race condition with functional updates
- modularize constants for clearer maintenance

## Testing
- `CI=true npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_6891350685d08320843941a6512e6ae9