### PR TITLE
feat: add accessible notifications with sound toggle

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,16 @@
 import React, { useState, useEffect, useRef } from 'react';
-import { Package, Coins, ChevronRight, AlertCircle, ChevronDown, ChevronUp, Sun, Moon } from 'lucide-react';
+import {
+  Package,
+  Coins,
+  ChevronRight,
+  AlertCircle,
+  ChevronDown,
+  ChevronUp,
+  Sun,
+  Moon,
+  Volume2,
+  VolumeX,
+} from 'lucide-react';
 import { PHASES, MATERIALS, BOX_TYPES } from './constants';
 import EventLog from './components/EventLog';
 import Notifications from './components/Notifications';
@@ -30,6 +41,16 @@ const MerchantsMorning = () => {
       return window.matchMedia('(prefers-color-scheme: dark)').matches;
     }
   });
+  const [soundEnabled, setSoundEnabled] = useState(() => {
+    if (typeof window === 'undefined') return true;
+    try {
+      const stored = window.localStorage.getItem('soundEnabled');
+      return stored ? stored === 'true' : true;
+    } catch (e) {
+      console.error('Failed to load sound preference', e);
+      return true;
+    }
+  });
   const notificationTimers = useRef([]);
 
   useEffect(() => {
@@ -48,6 +69,16 @@ const MerchantsMorning = () => {
       }
     }
   }, [darkMode]);
+
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      try {
+        window.localStorage.setItem('soundEnabled', soundEnabled);
+      } catch (e) {
+        console.error('Failed to save sound preference', e);
+      }
+    }
+  }, [soundEnabled]);
 
   useEffect(() => {
     return () => {
@@ -104,7 +135,7 @@ const MerchantsMorning = () => {
 
   return (
     <div className="min-h-screen bg-gradient-to-b from-amber-50 to-orange-100 pb-16 dark:from-gray-900 dark:to-gray-800 dark:text-gray-100">
-      <Notifications notifications={notifications} />
+      <Notifications notifications={notifications} soundEnabled={soundEnabled} />
       <div className="max-w-6xl mx-auto p-3">
         <div className="bg-white rounded-lg shadow-lg p-3 mb-3 flex items-center justify-between dark:bg-gray-800">
           <div>
@@ -122,6 +153,13 @@ const MerchantsMorning = () => {
               aria-label="Toggle dark mode"
             >
               {darkMode ? <Sun className="w-4 h-4 text-yellow-400" /> : <Moon className="w-4 h-4" />}
+            </button>
+            <button
+              onClick={() => setSoundEnabled(!soundEnabled)}
+              className="p-1 rounded bg-gray-100 hover:bg-gray-200 dark:bg-gray-700 dark:hover:bg-gray-600"
+              aria-label={soundEnabled ? 'Mute notification sounds' : 'Enable notification sounds'}
+            >
+              {soundEnabled ? <Volume2 className="w-4 h-4" /> : <VolumeX className="w-4 h-4" />}
             </button>
             <button
               onClick={() => setShowEventLog(!showEventLog)}

--- a/src/components/Notifications.jsx
+++ b/src/components/Notifications.jsx
@@ -1,23 +1,25 @@
 import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
+import { playNotificationSound, closeAudioContext } from '../utils/audio';
 
-const Notifications = ({ notifications }) => {
+const Notifications = ({ notifications, soundEnabled }) => {
   useEffect(() => {
+    if (!soundEnabled) return;
     if (notifications.length === 0) return;
-    const AudioCtx = typeof window !== 'undefined' && (window.AudioContext || window.webkitAudioContext);
-    if (!AudioCtx) return;
+    playNotificationSound();
+  }, [notifications, soundEnabled]);
 
-    const audioCtx = new AudioCtx();
-    const oscillator = audioCtx.createOscillator();
-    oscillator.type = 'sine';
-    oscillator.frequency.setValueAtTime(880, audioCtx.currentTime);
-    oscillator.connect(audioCtx.destination);
-    oscillator.start();
-    oscillator.stop(audioCtx.currentTime + 0.1);
-  }, [notifications]);
+  useEffect(() => {
+    if (!soundEnabled) {
+      closeAudioContext();
+    }
+    return () => {
+      closeAudioContext();
+    };
+  }, [soundEnabled]);
 
   return (
-    <div className="fixed top-4 right-4 space-y-2 z-50">
+    <div role="status" aria-live="polite" className="fixed top-4 right-4 space-y-2 z-50">
       {notifications.map(notification => (
         <div
           key={notification.id}
@@ -44,6 +46,11 @@ Notifications.propTypes = {
       type: PropTypes.string.isRequired,
     })
   ).isRequired,
+  soundEnabled: PropTypes.bool,
+};
+
+Notifications.defaultProps = {
+  soundEnabled: true,
 };
 
 export default Notifications;

--- a/src/components/__tests__/Notifications.test.jsx
+++ b/src/components/__tests__/Notifications.test.jsx
@@ -3,12 +3,13 @@ import { render, screen } from '@testing-library/react';
 import Notifications from '../Notifications.jsx';
 
 describe('Notifications', () => {
-  test('renders notifications', () => {
+  test('renders notifications with status role', () => {
     const notifications = [
       { id: 1, message: 'Hello', type: 'success' },
       { id: 2, message: 'Error', type: 'error' }
     ];
-    render(<Notifications notifications={notifications} />);
+    render(<Notifications notifications={notifications} soundEnabled={false} />);
+    expect(screen.getByRole('status')).toBeInTheDocument();
     expect(screen.getByText('Hello')).toBeInTheDocument();
     expect(screen.getByText('Error')).toBeInTheDocument();
   });

--- a/src/utils/audio.js
+++ b/src/utils/audio.js
@@ -1,0 +1,37 @@
+let audioCtx;
+
+function getAudioContext() {
+  if (audioCtx && audioCtx.state === 'closed') {
+    audioCtx = null;
+  }
+  if (!audioCtx) {
+    const AudioCtx =
+      typeof window !== 'undefined' && (window.AudioContext || window.webkitAudioContext);
+    if (AudioCtx) {
+      audioCtx = new AudioCtx();
+    }
+  }
+  return audioCtx;
+}
+
+export function playNotificationSound() {
+  const ctx = getAudioContext();
+  if (!ctx) return;
+  const oscillator = ctx.createOscillator();
+  oscillator.type = 'sine';
+  oscillator.frequency.setValueAtTime(880, ctx.currentTime);
+  oscillator.connect(ctx.destination);
+  oscillator.start();
+  oscillator.stop(ctx.currentTime + 0.1);
+}
+
+export async function closeAudioContext() {
+  if (audioCtx) {
+    try {
+      await audioCtx.close();
+    } catch (e) {
+      // ignore
+    }
+    audioCtx = null;
+  }
+}


### PR DESCRIPTION
## Summary
- improve Notifications accessibility with status role and polite live region
- centralize audio context and allow sound to be muted
- persist notification sound preference and expose toggle in UI

## Testing
- `npm test -- --watch=false`


------
https://chatgpt.com/codex/tasks/task_e_68913a3574e88320a05e034236814bc3