### PR TITLE
refactor: optimize sorting, rarity utilities, and memoization

### DIFF
--- a/src/hooks/useCustomers.js
+++ b/src/hooks/useCustomers.js
@@ -1,5 +1,6 @@
 import { PHASES, RECIPES } from '../constants';
 import { random } from '../utils/random';
+import { getRarityRank } from '../utils/rarity';
 
 const useCustomers = (gameState, setGameState, addEvent, addNotification, setSelectedCustomer) => {
   const generateCustomers = () => {
@@ -84,8 +85,7 @@ const useCustomers = (gameState, setGameState, addEvent, addNotification, setSel
         satisfaction = 'reluctant';
       }
 
-      const rarityOrder = { common: 1, uncommon: 2, rare: 3 };
-      if (rarityOrder[recipe.rarity] > rarityOrder[customer.requestRarity]) {
+      if (getRarityRank(recipe.rarity) > getRarityRank(customer.requestRarity)) {
         penalty -= 0.1;
         satisfaction = customer.isFlexible ? 'delighted upgrade' : 'acceptable upgrade';
       }

--- a/src/utils/rarity.js
+++ b/src/utils/rarity.js
@@ -1,0 +1,5 @@
+import { RARITY_ORDER } from '../constants';
+
+export const getRarityRank = (rarity) => RARITY_ORDER[rarity] || 0;
+
+export const compareRarities = (rarityA, rarityB) => getRarityRank(rarityA) - getRarityRank(rarityB);


### PR DESCRIPTION
## Summary
- avoid mutating arrays when sorting and unify rarity comparisons with new utility functions
- memoize crafting and shop inventory lists to cut rerender costs

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_689140322280832096b12df98be21884