### PR TITLE
refactor: memoize lists and unify rarity handling

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect, useRef, useMemo } from 'react';
 import { Package, Coins, ChevronRight, AlertCircle, ChevronDown, ChevronUp, Sun, Moon } from 'lucide-react';
 import { PHASES, MATERIALS, BOX_TYPES } from './constants';
 import EventLog from './components/EventLog';
@@ -98,6 +98,8 @@ const MerchantsMorning = () => {
     sortByMatchQualityAndRarity,
     getTopMaterials,
   } = useCrafting(gameState, setGameState, addEvent, addNotification);
+
+  const topMaterials = useMemo(() => getTopMaterials(), [getTopMaterials]);
 
   const { openShop, serveCustomer, endDay, startNewDay } =
     useCustomers(gameState, setGameState, addEvent, addNotification, setSelectedCustomer);
@@ -245,7 +247,7 @@ const MerchantsMorning = () => {
               {gameState.gold}
             </div>
             <div className="flex items-center gap-2 overflow-x-auto">
-              {getTopMaterials().map(([materialId, count]) => {
+              {topMaterials.map(([materialId, count]) => {
                 const material = MATERIALS[materialId];
                 return (
                   <div key={materialId} className="flex items-center gap-1 text-xs whitespace-nowrap">

--- a/src/features/ShopInterface.jsx
+++ b/src/features/ShopInterface.jsx
@@ -1,7 +1,8 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { Store } from 'lucide-react';
 import TabButton from '../components/TabButton';
 import { ITEM_TYPES, RECIPES } from '../constants';
+import { getRarityRank } from '../utils/rarity';
 
 const ShopInterface = ({
   gameState,
@@ -14,7 +15,18 @@ const ShopInterface = ({
   serveCustomer,
   endDay,
   getRarityColor,
-}) => (
+}) => {
+  const filteredInventory = useMemo(
+    () => filterInventoryByType(sellingTab),
+    [filterInventoryByType, sellingTab]
+  );
+
+  const sortedInventory = useMemo(
+    () => sortByMatchQualityAndRarity(filteredInventory, selectedCustomer),
+    [filteredInventory, selectedCustomer, sortByMatchQualityAndRarity]
+  );
+
+  return (
   <div className="space-y-4">
     <div className="bg-white rounded-lg shadow-lg p-4 dark:bg-gray-800">
       <h2 className="text-lg font-bold mb-3 flex items-center gap-2">
@@ -98,7 +110,7 @@ const ShopInterface = ({
       </div>
 
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 max-h-96 overflow-y-auto">
-        {sortByMatchQualityAndRarity(filterInventoryByType(sellingTab), selectedCustomer).map(([itemId, count]) => {
+        {sortedInventory.map(([itemId, count]) => {
           const recipe = RECIPES.find(r => r.id === itemId);
 
           let saleInfo = null;
@@ -111,8 +123,7 @@ const ShopInterface = ({
 
             if (!exactMatch) {
               let penalty = selectedCustomer.isFlexible ? 0.2 : 0.4;
-              const rarityOrder = { common: 1, uncommon: 2, rare: 3 };
-              if (rarityOrder[recipe.rarity] > rarityOrder[selectedCustomer.requestRarity]) {
+              if (getRarityRank(recipe.rarity) > getRarityRank(selectedCustomer.requestRarity)) {
                 penalty -= 0.1;
                 status = 'upgrade';
               } else if (recipe.type === selectedCustomer.requestType) {
@@ -182,7 +193,7 @@ const ShopInterface = ({
           );
         })}
 
-        {filterInventoryByType(sellingTab).length === 0 && (
+        {filteredInventory.length === 0 && (
           <div className="col-span-full text-center py-8">
             <p className="text-gray-500 italic dark:text-gray-400">No {sellingTab}s in stock</p>
             <p className="text-xs text-gray-400 mt-1 dark:text-gray-500">Craft some items to sell!</p>
@@ -191,6 +202,7 @@ const ShopInterface = ({
       </div>
     </div>
   </div>
-);
+  );
+};
 
 export default ShopInterface;

--- a/src/hooks/useCrafting.js
+++ b/src/hooks/useCrafting.js
@@ -1,5 +1,6 @@
-import { MATERIALS, RECIPES, BOX_TYPES, RARITY_ORDER } from '../constants';
+import { MATERIALS, RECIPES, BOX_TYPES } from '../constants';
 import { random } from '../utils/random';
+import { getRarityRank } from '../utils/rarity';
 
 const useCrafting = (gameState, setGameState, addEvent, addNotification) => {
   const getRandomMaterial = (rarityWeights) => {
@@ -85,26 +86,25 @@ const useCrafting = (gameState, setGameState, addEvent, addNotification) => {
       });
 
   const sortRecipesByRarityAndCraftability = (recipes) =>
-    recipes.sort((a, b) => {
+    [...recipes].sort((a, b) => {
       const canCraftA = canCraft(a);
       const canCraftB = canCraft(b);
       if (canCraftA && !canCraftB) return -1;
       if (!canCraftA && canCraftB) return 1;
-      return RARITY_ORDER[b.rarity] - RARITY_ORDER[a.rarity];
+      return getRarityRank(b.rarity) - getRarityRank(a.rarity);
     });
 
   const sortByMatchQualityAndRarity = (inventoryItems, customer) =>
-    inventoryItems.sort((a, b) => {
+    [...inventoryItems].sort((a, b) => {
       const recipeA = RECIPES.find(r => r.id === a[0]);
       const recipeB = RECIPES.find(r => r.id === b[0]);
       if (!customer) {
-        return RARITY_ORDER[recipeB.rarity] - RARITY_ORDER[recipeA.rarity];
+        return getRarityRank(recipeB.rarity) - getRarityRank(recipeA.rarity);
       }
       const getMatchScore = (recipe) => {
         const exactMatch = recipe.type === customer.requestType && recipe.rarity === customer.requestRarity;
         if (exactMatch) return 4;
-        const rarityOrder = { common: 1, uncommon: 2, rare: 3 };
-        if (rarityOrder[recipe.rarity] > rarityOrder[customer.requestRarity] && recipe.type === customer.requestType) {
+        if (getRarityRank(recipe.rarity) > getRarityRank(customer.requestRarity) && recipe.type === customer.requestType) {
           return 3;
         }
         if (recipe.type === customer.requestType) {
@@ -120,7 +120,7 @@ const useCrafting = (gameState, setGameState, addEvent, addNotification) => {
       if (scoreA !== scoreB) {
         return scoreB - scoreA;
       }
-      return RARITY_ORDER[recipeB.rarity] - RARITY_ORDER[recipeA.rarity];
+      return getRarityRank(recipeB.rarity) - getRarityRank(recipeA.rarity);
     });
 
   const getTopMaterials = () =>

--- a/src/hooks/useCustomers.js
+++ b/src/hooks/useCustomers.js
@@ -1,5 +1,6 @@
 import { PHASES, RECIPES } from '../constants';
 import { random } from '../utils/random';
+import { getRarityRank } from '../utils/rarity';
 
 const useCustomers = (gameState, setGameState, addEvent, addNotification, setSelectedCustomer) => {
   const generateCustomers = () => {
@@ -84,8 +85,7 @@ const useCustomers = (gameState, setGameState, addEvent, addNotification, setSel
         satisfaction = 'reluctant';
       }
 
-      const rarityOrder = { common: 1, uncommon: 2, rare: 3 };
-      if (rarityOrder[recipe.rarity] > rarityOrder[customer.requestRarity]) {
+      if (getRarityRank(recipe.rarity) > getRarityRank(customer.requestRarity)) {
         penalty -= 0.1;
         satisfaction = customer.isFlexible ? 'delighted upgrade' : 'acceptable upgrade';
       }

--- a/src/utils/rarity.js
+++ b/src/utils/rarity.js
@@ -1,0 +1,6 @@
+import { RARITY_ORDER } from '../constants';
+
+export const getRarityRank = (rarity) => RARITY_ORDER[rarity] || 0;
+
+export const compareRarities = (rarityA, rarityB) => getRarityRank(rarityA) - getRarityRank(rarityB);
+


### PR DESCRIPTION
## Summary
- centralize rarity comparisons
- avoid in-place sorting
- memoize crafting and selling list calculations

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_689140322280832096b12df98be21884