### PR TITLE
Add prop types and tests

### DIFF
--- a/src/components/TabButton.jsx
+++ b/src/components/TabButton.jsx
@@ -19,7 +19,7 @@ TabButton.propTypes = {
   active: PropTypes.bool,
   onClick: PropTypes.func.isRequired,
   children: PropTypes.node.isRequired,
-  count: PropTypes.number,
+  count: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
 };
 
 export default TabButton;

--- a/src/features/CraftingPanel.jsx
+++ b/src/features/CraftingPanel.jsx
@@ -1,4 +1,5 @@
 import React, { useMemo } from 'react';
+import PropTypes from 'prop-types';
 import { Hammer, Store } from 'lucide-react';
 import { MATERIALS, RECIPES, ITEM_TYPES } from '../constants';
 import TabButton from '../components/TabButton';
@@ -151,3 +152,21 @@ const CraftingPanel = ({
 };
 
 export default CraftingPanel;
+
+CraftingPanel.propTypes = {
+  gameState: PropTypes.shape({
+    materials: PropTypes.object.isRequired,
+    inventory: PropTypes.object.isRequired,
+  }).isRequired,
+  craftingTab: PropTypes.oneOf(ITEM_TYPES).isRequired,
+  setCraftingTab: PropTypes.func.isRequired,
+  inventoryTab: PropTypes.oneOf(ITEM_TYPES).isRequired,
+  setInventoryTab: PropTypes.func.isRequired,
+  canCraft: PropTypes.func.isRequired,
+  craftItem: PropTypes.func.isRequired,
+  filterRecipesByType: PropTypes.func.isRequired,
+  sortRecipesByRarityAndCraftability: PropTypes.func.isRequired,
+  filterInventoryByType: PropTypes.func.isRequired,
+  openShop: PropTypes.func.isRequired,
+  getRarityColor: PropTypes.func.isRequired,
+};

--- a/src/features/EndOfDaySummary.jsx
+++ b/src/features/EndOfDaySummary.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { Star } from 'lucide-react';
 
 const EndOfDaySummary = ({ gameState, startNewDay }) => (
@@ -34,3 +35,11 @@ const EndOfDaySummary = ({ gameState, startNewDay }) => (
 );
 
 export default EndOfDaySummary;
+
+EndOfDaySummary.propTypes = {
+  gameState: PropTypes.shape({
+    day: PropTypes.number.isRequired,
+    customers: PropTypes.array.isRequired,
+  }).isRequired,
+  startNewDay: PropTypes.func.isRequired,
+};

--- a/src/features/ShopInterface.jsx
+++ b/src/features/ShopInterface.jsx
@@ -1,4 +1,5 @@
 import React, { useMemo } from 'react';
+import PropTypes from 'prop-types';
 import { Store } from 'lucide-react';
 import TabButton from '../components/TabButton';
 import { ITEM_TYPES, RECIPES } from '../constants';
@@ -201,3 +202,27 @@ const ShopInterface = ({
 };
 
 export default ShopInterface;
+
+ShopInterface.propTypes = {
+  gameState: PropTypes.shape({
+    customers: PropTypes.array.isRequired,
+    inventory: PropTypes.object.isRequired,
+  }).isRequired,
+  selectedCustomer: PropTypes.shape({
+    id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+    name: PropTypes.string,
+    requestType: PropTypes.string,
+    requestRarity: PropTypes.string,
+    offerPrice: PropTypes.number,
+    isFlexible: PropTypes.bool,
+    satisfied: PropTypes.bool,
+  }),
+  setSelectedCustomer: PropTypes.func.isRequired,
+  sellingTab: PropTypes.oneOf(ITEM_TYPES).isRequired,
+  setSellingTab: PropTypes.func.isRequired,
+  filterInventoryByType: PropTypes.func.isRequired,
+  sortByMatchQualityAndRarity: PropTypes.func.isRequired,
+  serveCustomer: PropTypes.func.isRequired,
+  endDay: PropTypes.func.isRequired,
+  getRarityColor: PropTypes.func.isRequired,
+};

--- a/src/features/__tests__/CraftingPanel.test.jsx
+++ b/src/features/__tests__/CraftingPanel.test.jsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import CraftingPanel from '../CraftingPanel.jsx';
+import { RECIPES } from '../../constants';
+
+describe('CraftingPanel', () => {
+  test('renders recipes, allows crafting and opening shop', () => {
+    const recipe = RECIPES.find(r => r.id === 'iron_dagger');
+    const props = {
+      gameState: { materials: { iron: 1, wood: 1 }, inventory: { iron_dagger: 1 } },
+      craftingTab: 'weapon',
+      setCraftingTab: jest.fn(),
+      inventoryTab: 'weapon',
+      setInventoryTab: jest.fn(),
+      canCraft: jest.fn(() => true),
+      craftItem: jest.fn(),
+      filterRecipesByType: jest.fn(() => [recipe]),
+      sortRecipesByRarityAndCraftability: jest.fn(r => r),
+      filterInventoryByType: jest.fn(() => [['iron_dagger', 1]]),
+      openShop: jest.fn(),
+      getRarityColor: jest.fn(() => 'color'),
+    };
+
+    render(<CraftingPanel {...props} />);
+
+    fireEvent.click(screen.getByText('✓ Craft'));
+    expect(props.craftItem).toHaveBeenCalledWith('iron_dagger');
+
+    fireEvent.click(screen.getByRole('button', { name: /open shop/i }));
+    expect(props.openShop).toHaveBeenCalled();
+  });
+});

--- a/src/features/__tests__/EndOfDaySummary.test.jsx
+++ b/src/features/__tests__/EndOfDaySummary.test.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import EndOfDaySummary from '../EndOfDaySummary.jsx';
+
+describe('EndOfDaySummary', () => {
+  test('renders summary and starts new day', () => {
+    const props = {
+      gameState: {
+        day: 1,
+        customers: [
+          { satisfied: true, payment: 10 },
+          { satisfied: false, payment: 0 },
+        ],
+      },
+      startNewDay: jest.fn(),
+    };
+
+    render(<EndOfDaySummary {...props} />);
+
+    expect(screen.getByText('Day 1 Complete!')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /start day 2/i }));
+    expect(props.startNewDay).toHaveBeenCalled();
+  });
+});

--- a/src/features/__tests__/ShopInterface.test.jsx
+++ b/src/features/__tests__/ShopInterface.test.jsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import ShopInterface from '../ShopInterface.jsx';
+
+const recipeId = 'iron_dagger';
+
+describe('ShopInterface', () => {
+  test('sells items to selected customer and ends day', () => {
+    const customer = {
+      id: 'c1',
+      name: 'Bob',
+      requestType: 'weapon',
+      requestRarity: 'common',
+      offerPrice: 10,
+      satisfied: false,
+      isFlexible: false,
+    };
+
+    const props = {
+      gameState: { customers: [customer], inventory: { [recipeId]: 1 } },
+      selectedCustomer: customer,
+      setSelectedCustomer: jest.fn(),
+      sellingTab: 'weapon',
+      setSellingTab: jest.fn(),
+      filterInventoryByType: jest.fn(() => [[recipeId, 1]]),
+      sortByMatchQualityAndRarity: jest.fn(items => items),
+      serveCustomer: jest.fn(),
+      endDay: jest.fn(),
+      getRarityColor: jest.fn(() => 'color'),
+    };
+
+    render(<ShopInterface {...props} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /sell to bob/i }));
+    expect(props.serveCustomer).toHaveBeenCalledWith('c1', recipeId);
+
+    fireEvent.click(screen.getByRole('button', { name: /close shop for today/i }));
+    expect(props.endDay).toHaveBeenCalled();
+  });
+});

--- a/src/hooks/__tests__/sortingHelpers.test.js
+++ b/src/hooks/__tests__/sortingHelpers.test.js
@@ -1,0 +1,55 @@
+import useCrafting from '../useCrafting';
+import { RECIPES } from '../../constants';
+
+describe('sorting helpers', () => {
+  test('sortRecipesByRarityAndCraftability sorts correctly without mutating', () => {
+    const gameState = {
+      materials: { iron: 2, wood: 1 },
+      inventory: {},
+    };
+    const setState = () => {};
+    const { sortRecipesByRarityAndCraftability } = useCrafting(gameState, setState, jest.fn(), jest.fn());
+    const recipes = [
+      RECIPES.find(r => r.id === 'iron_sword'), // uncommon
+      RECIPES.find(r => r.id === 'iron_dagger'), // common
+    ];
+    const original = [...recipes];
+
+    const sorted = sortRecipesByRarityAndCraftability(recipes);
+
+    expect(sorted[0].id).toBe('iron_dagger'); // craftable comes first
+    expect(recipes).toEqual(original); // input not mutated
+  });
+
+  test('sortRecipesByRarityAndCraftability handles empty array', () => {
+    const { sortRecipesByRarityAndCraftability } = useCrafting({ materials: {}, inventory: {} }, () => {}, jest.fn(), jest.fn());
+    const recipes = [];
+    const sorted = sortRecipesByRarityAndCraftability(recipes);
+    expect(sorted).toEqual([]);
+    expect(recipes).toEqual([]);
+  });
+
+  test('sortByMatchQualityAndRarity sorts by match quality without mutating', () => {
+    const gameState = { inventory: { iron_dagger: 1, iron_sword: 1 }, materials: {} };
+    const setState = () => {};
+    const { sortByMatchQualityAndRarity } = useCrafting(gameState, setState, jest.fn(), jest.fn());
+    const items = [ ['iron_sword', 1], ['iron_dagger', 1] ];
+    const original = JSON.parse(JSON.stringify(items));
+    const customer = { requestType: 'weapon', requestRarity: 'common', isFlexible: false };
+
+    const sorted = sortByMatchQualityAndRarity(items, customer);
+
+    expect(sorted[0][0]).toBe('iron_dagger'); // exact match first
+    expect(items).toEqual(original); // input not mutated
+  });
+
+  test('sortByMatchQualityAndRarity handles empty inventory', () => {
+    const gameState = { inventory: {}, materials: {} };
+    const setState = () => {};
+    const { sortByMatchQualityAndRarity } = useCrafting(gameState, setState, jest.fn(), jest.fn());
+    const items = [];
+    const sorted = sortByMatchQualityAndRarity(items, null);
+    expect(sorted).toEqual([]);
+    expect(items).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- add PropTypes to CraftingPanel, ShopInterface, and EndOfDaySummary
- cover core game logic and sorting helpers with new unit tests
- test key feature components for rendering and interaction

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_689143c5df808320b9763fa5844b4a6f