### PR TITLE
Add PropTypes and broaden test coverage

### DIFF
--- a/src/components/TabButton.jsx
+++ b/src/components/TabButton.jsx
@@ -19,7 +19,7 @@ TabButton.propTypes = {
   active: PropTypes.bool,
   onClick: PropTypes.func.isRequired,
   children: PropTypes.node.isRequired,
-  count: PropTypes.number,
+  count: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
 };
 
 export default TabButton;

--- a/src/features/CraftingPanel.jsx
+++ b/src/features/CraftingPanel.jsx
@@ -1,4 +1,5 @@
 import React, { useMemo } from 'react';
+import PropTypes from 'prop-types';
 import { Hammer, Store } from 'lucide-react';
 import { MATERIALS, RECIPES, ITEM_TYPES } from '../constants';
 import TabButton from '../components/TabButton';
@@ -148,6 +149,24 @@ const CraftingPanel = ({
     </div>
   </div>
   );
+};
+
+CraftingPanel.propTypes = {
+  gameState: PropTypes.shape({
+    materials: PropTypes.object.isRequired,
+    inventory: PropTypes.object.isRequired,
+  }).isRequired,
+  craftingTab: PropTypes.string.isRequired,
+  setCraftingTab: PropTypes.func.isRequired,
+  inventoryTab: PropTypes.string.isRequired,
+  setInventoryTab: PropTypes.func.isRequired,
+  canCraft: PropTypes.func.isRequired,
+  craftItem: PropTypes.func.isRequired,
+  filterRecipesByType: PropTypes.func.isRequired,
+  sortRecipesByRarityAndCraftability: PropTypes.func.isRequired,
+  filterInventoryByType: PropTypes.func.isRequired,
+  openShop: PropTypes.func.isRequired,
+  getRarityColor: PropTypes.func.isRequired,
 };
 
 export default CraftingPanel;

--- a/src/features/EndOfDaySummary.jsx
+++ b/src/features/EndOfDaySummary.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { Star } from 'lucide-react';
 
 const EndOfDaySummary = ({ gameState, startNewDay }) => (
@@ -32,5 +33,18 @@ const EndOfDaySummary = ({ gameState, startNewDay }) => (
     </button>
   </div>
 );
+
+EndOfDaySummary.propTypes = {
+  gameState: PropTypes.shape({
+    day: PropTypes.number.isRequired,
+    customers: PropTypes.arrayOf(
+      PropTypes.shape({
+        payment: PropTypes.number,
+        satisfied: PropTypes.bool,
+      })
+    ).isRequired,
+  }).isRequired,
+  startNewDay: PropTypes.func.isRequired,
+};
 
 export default EndOfDaySummary;

--- a/src/features/ShopInterface.jsx
+++ b/src/features/ShopInterface.jsx
@@ -1,4 +1,5 @@
 import React, { useMemo } from 'react';
+import PropTypes from 'prop-types';
 import { Store } from 'lucide-react';
 import TabButton from '../components/TabButton';
 import { ITEM_TYPES, RECIPES } from '../constants';
@@ -198,6 +199,31 @@ const ShopInterface = ({
     </div>
   </div>
   );
+};
+
+ShopInterface.propTypes = {
+  gameState: PropTypes.shape({
+    customers: PropTypes.array.isRequired,
+    inventory: PropTypes.object.isRequired,
+  }).isRequired,
+  selectedCustomer: PropTypes.shape({
+    id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+    name: PropTypes.string.isRequired,
+    requestType: PropTypes.string.isRequired,
+    requestRarity: PropTypes.string.isRequired,
+    offerPrice: PropTypes.number.isRequired,
+    satisfied: PropTypes.bool,
+    isFlexible: PropTypes.bool,
+    payment: PropTypes.number,
+  }),
+  setSelectedCustomer: PropTypes.func.isRequired,
+  sellingTab: PropTypes.string.isRequired,
+  setSellingTab: PropTypes.func.isRequired,
+  filterInventoryByType: PropTypes.func.isRequired,
+  sortByMatchQualityAndRarity: PropTypes.func.isRequired,
+  serveCustomer: PropTypes.func.isRequired,
+  endDay: PropTypes.func.isRequired,
+  getRarityColor: PropTypes.func.isRequired,
 };
 
 export default ShopInterface;

--- a/src/features/__tests__/CraftingPanel.test.jsx
+++ b/src/features/__tests__/CraftingPanel.test.jsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import CraftingPanel from '../CraftingPanel.jsx';
+
+describe('CraftingPanel', () => {
+  test('renders recipes and handles crafting and shop opening', () => {
+    const gameState = { materials: {}, inventory: {} };
+    const recipe = { id: 'r1', name: 'Test Item', ingredients: {}, rarity: 'common' };
+
+    const props = {
+      gameState,
+      craftingTab: 'weapon',
+      setCraftingTab: jest.fn(),
+      inventoryTab: 'weapon',
+      setInventoryTab: jest.fn(),
+      canCraft: jest.fn(() => true),
+      craftItem: jest.fn(),
+      filterRecipesByType: jest.fn(() => [recipe]),
+      sortRecipesByRarityAndCraftability: jest.fn(recipes => recipes),
+      filterInventoryByType: jest.fn(() => []),
+      openShop: jest.fn(),
+      getRarityColor: jest.fn(() => 'border-gray-200'),
+    };
+
+    render(<CraftingPanel {...props} />);
+
+    expect(screen.getByText('Test Item')).toBeInTheDocument();
+    fireEvent.click(screen.getByText('✓ Craft'));
+    expect(props.craftItem).toHaveBeenCalledWith('r1');
+
+    fireEvent.click(screen.getByText(/Open Shop/));
+    expect(props.openShop).toHaveBeenCalled();
+  });
+});

--- a/src/features/__tests__/EndOfDaySummary.test.jsx
+++ b/src/features/__tests__/EndOfDaySummary.test.jsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import EndOfDaySummary from '../EndOfDaySummary.jsx';
+
+describe('EndOfDaySummary', () => {
+  test('shows summary and starts new day', () => {
+    const gameState = {
+      day: 1,
+      customers: [
+        { payment: 5, satisfied: true },
+        { payment: 0, satisfied: false },
+      ],
+    };
+    const startNewDay = jest.fn();
+
+    render(<EndOfDaySummary gameState={gameState} startNewDay={startNewDay} />);
+
+    expect(screen.getByText('Day 1 Complete!')).toBeInTheDocument();
+    expect(screen.getByText('5 Gold')).toBeInTheDocument();
+    expect(screen.getByText('1 / 2')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('Start Day 2'));
+    expect(startNewDay).toHaveBeenCalled();
+  });
+});

--- a/src/features/__tests__/ShopInterface.test.jsx
+++ b/src/features/__tests__/ShopInterface.test.jsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import ShopInterface from '../ShopInterface.jsx';
+
+describe('ShopInterface', () => {
+  test('selects customer and sells item', () => {
+    const customer = {
+      id: 'c1',
+      name: 'Alice',
+      requestType: 'weapon',
+      requestRarity: 'common',
+      offerPrice: 10,
+      satisfied: false,
+      isFlexible: false,
+    };
+
+    const props = {
+      gameState: { customers: [customer], inventory: { iron_dagger: 1 } },
+      selectedCustomer: null,
+      setSelectedCustomer: jest.fn(),
+      sellingTab: 'weapon',
+      setSellingTab: jest.fn(),
+      filterInventoryByType: jest.fn(() => [['iron_dagger', 1]]),
+      sortByMatchQualityAndRarity: jest.fn(items => items),
+      serveCustomer: jest.fn(),
+      endDay: jest.fn(),
+      getRarityColor: jest.fn(() => 'border-gray-200'),
+    };
+
+    const { rerender } = render(<ShopInterface {...props} />);
+
+    fireEvent.click(screen.getByText('Alice'));
+    expect(props.setSelectedCustomer).toHaveBeenCalledWith(customer);
+    expect(props.setSellingTab).toHaveBeenCalledWith('weapon');
+
+    rerender(<ShopInterface {...props} selectedCustomer={customer} />);
+
+    fireEvent.click(screen.getByText('Sell to Alice'));
+    expect(props.serveCustomer).toHaveBeenCalledWith('c1', 'iron_dagger');
+
+    fireEvent.click(screen.getByText('Close Shop for Today'));
+    expect(props.endDay).toHaveBeenCalled();
+  });
+});

--- a/src/hooks/__tests__/gameLogic.test.js
+++ b/src/hooks/__tests__/gameLogic.test.js
@@ -37,15 +37,96 @@ describe('core game logic', () => {
     expect(state.inventory.iron_dagger).toBe(1);
   });
 
+  test('craftItem does nothing if materials are insufficient', () => {
+    let state = { materials: { iron: 1 }, inventory: {}, gold: 0, phase: PHASES.CRAFTING };
+    const setState = (fn) => { state = typeof fn === 'function' ? fn(state) : fn; };
+    const { craftItem } = useCrafting(state, setState, jest.fn(), jest.fn());
+
+    craftItem('iron_dagger');
+
+    expect(state.materials).toEqual({ iron: 1 });
+    expect(state.inventory).toEqual({});
+  });
+
   test('startNewDay resets customers and increments day', () => {
     let state = { phase: PHASES.END_DAY, day: 1, customers: [{ id: '1' }], inventory: {}, gold: 0, totalEarnings: 0 };
     const setState = (fn) => { state = typeof fn === 'function' ? fn(state) : fn; };
-    const { startNewDay } = useCustomers(state, setState, jest.fn(), jest.fn(), jest.fn());
+    const setSelectedCustomer = jest.fn();
+    const { startNewDay } = useCustomers(state, setState, jest.fn(), jest.fn(), setSelectedCustomer);
 
     startNewDay();
 
     expect(state.day).toBe(2);
     expect(state.phase).toBe(PHASES.MORNING);
     expect(state.customers).toEqual([]);
+    expect(setSelectedCustomer).toHaveBeenCalledWith(null);
+  });
+
+  test('openBox does not spend gold if insufficient funds', () => {
+    let state = { gold: 10, materials: {}, inventory: {}, phase: PHASES.MORNING };
+    const setState = (fn) => { state = typeof fn === 'function' ? fn(state) : fn; };
+    const { openBox } = useCrafting(state, setState, jest.fn(), jest.fn());
+
+    openBox('bronze');
+
+    expect(state.gold).toBe(10);
+    expect(state.materials).toEqual({});
+  });
+
+  test('serveCustomer reduces inventory and adds gold', () => {
+    let state = {
+      inventory: { iron_dagger: 1 },
+      gold: 0,
+      customers: [
+        {
+          id: 'c1',
+          name: 'Test',
+          requestType: 'weapon',
+          requestRarity: 'common',
+          offerPrice: 10,
+          satisfied: false,
+          isFlexible: false,
+        },
+      ],
+      totalEarnings: 0,
+      phase: PHASES.SHOPPING,
+    };
+    const setState = (fn) => { state = typeof fn === 'function' ? fn(state) : fn; };
+    const { serveCustomer } = useCustomers(state, setState, jest.fn(), jest.fn(), jest.fn());
+
+    serveCustomer('c1', 'iron_dagger');
+
+    expect(state.inventory.iron_dagger).toBe(0);
+    expect(state.gold).toBe(10);
+    expect(state.customers[0].satisfied).toBe(true);
+    expect(state.customers[0].payment).toBe(10);
+  });
+
+  test('serveCustomer applies penalties for upgrades and wrong rarity', () => {
+    let state = {
+      inventory: { iron_sword: 1 },
+      gold: 0,
+      customers: [
+        {
+          id: 'c1',
+          name: 'Test',
+          requestType: 'weapon',
+          requestRarity: 'common',
+          offerPrice: 100,
+          satisfied: false,
+          isFlexible: false,
+        },
+      ],
+      totalEarnings: 0,
+      phase: PHASES.SHOPPING,
+    };
+    const setState = (fn) => { state = typeof fn === 'function' ? fn(state) : fn; };
+    const { serveCustomer } = useCustomers(state, setState, jest.fn(), jest.fn(), jest.fn());
+
+    serveCustomer('c1', 'iron_sword');
+
+    expect(state.gold).toBe(80); // 20% penalty applied
+    expect(state.customers[0].payment).toBe(80);
+    expect(state.customers[0].satisfaction).toBe('acceptable upgrade');
   });
 });

--- a/src/hooks/__tests__/sortingHelpers.test.js
+++ b/src/hooks/__tests__/sortingHelpers.test.js
@@ -1,0 +1,33 @@
+import useCrafting from '../useCrafting';
+import { RECIPES } from '../../constants';
+import { PHASES } from '../../constants';
+
+describe('sorting helpers', () => {
+  test('sortRecipesByRarityAndCraftability prioritizes craftable recipes and preserves input', () => {
+    const state = { materials: { iron: 2, wood: 1 }, inventory: {}, phase: PHASES.CRAFTING };
+    const { sortRecipesByRarityAndCraftability } = useCrafting(state, () => {}, jest.fn(), jest.fn());
+    const recipes = RECIPES.filter(r => ['iron_dagger', 'iron_sword'].includes(r.id));
+    const copy = [...recipes];
+
+    const result = sortRecipesByRarityAndCraftability(recipes);
+
+    expect(result.map(r => r.id)).toEqual(['iron_dagger', 'iron_sword']);
+    expect(recipes).toEqual(copy);
+  });
+
+  test('sortByMatchQualityAndRarity respects customer preferences and preserves input', () => {
+    const state = { materials: {}, inventory: {}, phase: PHASES.SHOPPING };
+    const { sortByMatchQualityAndRarity } = useCrafting(state, () => {}, jest.fn(), jest.fn());
+    const inventory = [ ['iron_dagger', 1], ['iron_sword', 1] ];
+    const copy = [...inventory];
+
+    const customer = { requestType: 'weapon', requestRarity: 'common', isFlexible: false, offerPrice: 0 };
+
+    const result = sortByMatchQualityAndRarity(inventory, customer);
+    expect(result[0][0]).toBe('iron_dagger');
+    expect(inventory).toEqual(copy);
+
+    const resultNoCustomer = sortByMatchQualityAndRarity(inventory, null);
+    expect(resultNoCustomer[0][0]).toBe('iron_sword');
+  });
+});


### PR DESCRIPTION
## Summary
- add PropTypes for CraftingPanel, ShopInterface, EndOfDaySummary and update TabButton count typing
- implement unit tests for core game logic and sorting helpers
- test CraftingPanel, ShopInterface, and EndOfDaySummary with React Testing Library

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_689143c5df808320b9763fa5844b4a6f