### PR TITLE
refactor: simplify notifications without audio

### DIFF
--- a/src/components/Archived/NotificationsWithAudio.jsx
+++ b/src/components/Archived/NotificationsWithAudio.jsx
@@ -1,0 +1,97 @@
+import React, { useEffect, useRef, useState } from 'react';
+import PropTypes from 'prop-types';
+
+const Notifications = ({ notifications, soundEnabled: defaultSoundEnabled = true }) => {
+  const audioCtxRef = useRef(null);
+  const [soundEnabled, setSoundEnabled] = useState(() => {
+    if (typeof window !== 'undefined') {
+      const stored = window.localStorage.getItem('notificationSoundEnabled');
+      if (stored !== null) return stored === 'true';
+    }
+    return defaultSoundEnabled;
+  });
+
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      window.localStorage.setItem('notificationSoundEnabled', soundEnabled);
+    }
+  }, [soundEnabled]);
+
+  useEffect(() => {
+    const AudioCtx = typeof window !== 'undefined' && (window.AudioContext || window.webkitAudioContext);
+    if (!soundEnabled || !AudioCtx) {
+      if (audioCtxRef.current) {
+        audioCtxRef.current.close();
+        audioCtxRef.current = null;
+      }
+      return;
+    }
+    if (!audioCtxRef.current) {
+      audioCtxRef.current = new AudioCtx();
+    }
+    return () => {
+      if (audioCtxRef.current) {
+        audioCtxRef.current.close();
+        audioCtxRef.current = null;
+      }
+    };
+  }, [soundEnabled]);
+
+  useEffect(() => {
+    if (!soundEnabled || notifications.length === 0) return;
+    const audioCtx = audioCtxRef.current;
+    if (!audioCtx) return;
+    const oscillator = audioCtx.createOscillator();
+    oscillator.type = 'sine';
+    oscillator.frequency.setValueAtTime(880, audioCtx.currentTime);
+    oscillator.connect(audioCtx.destination);
+    oscillator.start();
+    oscillator.stop(audioCtx.currentTime + 0.1);
+  }, [notifications, soundEnabled]);
+
+  const toggleSound = () => {
+    setSoundEnabled(prev => !prev);
+  };
+
+  return (
+    <div className="fixed top-4 right-4 space-y-2 z-50">
+      <button
+        type="button"
+        onClick={toggleSound}
+        className="px-2 py-1 rounded bg-gray-700 text-white"
+        aria-pressed={soundEnabled}
+      >
+        {soundEnabled ? 'Mute sound' : 'Enable sound'}
+      </button>
+      <div role="status" aria-live="polite" aria-atomic="true">
+        {notifications.map(notification => (
+          <div
+            key={notification.id}
+            className={`px-4 py-2 rounded-lg shadow-lg text-white font-medium animate-slide-in animate-pulse ${
+              notification.type === 'success'
+                ? 'bg-green-500'
+                : notification.type === 'error'
+                ? 'bg-red-500'
+                : 'bg-blue-500'
+            }`}
+          >
+            {notification.message}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+Notifications.propTypes = {
+  notifications: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+      message: PropTypes.string.isRequired,
+      type: PropTypes.string.isRequired,
+    })
+  ).isRequired,
+  soundEnabled: PropTypes.bool,
+};
+
+export default Notifications;

--- a/src/components/Notifications.jsx
+++ b/src/components/Notifications.jsx
@@ -1,87 +1,24 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 
-const Notifications = ({ notifications, soundEnabled: defaultSoundEnabled = true }) => {
-  const audioCtxRef = useRef(null);
-  const [soundEnabled, setSoundEnabled] = useState(() => {
-    if (typeof window !== 'undefined') {
-      const stored = window.localStorage.getItem('notificationSoundEnabled');
-      if (stored !== null) return stored === 'true';
-    }
-    return defaultSoundEnabled;
-  });
-
-  useEffect(() => {
-    if (typeof window !== 'undefined') {
-      window.localStorage.setItem('notificationSoundEnabled', soundEnabled);
-    }
-  }, [soundEnabled]);
-
-  useEffect(() => {
-    const AudioCtx = typeof window !== 'undefined' && (window.AudioContext || window.webkitAudioContext);
-    if (!soundEnabled || !AudioCtx) {
-      if (audioCtxRef.current) {
-        audioCtxRef.current.close();
-        audioCtxRef.current = null;
-      }
-      return;
-    }
-    if (!audioCtxRef.current) {
-      audioCtxRef.current = new AudioCtx();
-    }
-    return () => {
-      if (audioCtxRef.current) {
-        audioCtxRef.current.close();
-        audioCtxRef.current = null;
-      }
-    };
-  }, [soundEnabled]);
-
-  useEffect(() => {
-    if (!soundEnabled || notifications.length === 0) return;
-    const audioCtx = audioCtxRef.current;
-    if (!audioCtx) return;
-    const oscillator = audioCtx.createOscillator();
-    oscillator.type = 'sine';
-    oscillator.frequency.setValueAtTime(880, audioCtx.currentTime);
-    oscillator.connect(audioCtx.destination);
-    oscillator.start();
-    oscillator.stop(audioCtx.currentTime + 0.1);
-  }, [notifications, soundEnabled]);
-
-  const toggleSound = () => {
-    setSoundEnabled(prev => !prev);
-  };
-
-  return (
-    <div className="fixed top-4 right-4 space-y-2 z-50">
-      <button
-        type="button"
-        onClick={toggleSound}
-        className="px-2 py-1 rounded bg-gray-700 text-white"
-        aria-pressed={soundEnabled}
+const Notifications = ({ notifications }) => (
+  <div className="fixed top-4 right-4 space-y-2 z-50">
+    {notifications.map(notification => (
+      <div
+        key={notification.id}
+        className={`px-4 py-2 rounded-lg shadow-lg text-white font-medium animate-slide-in animate-pulse ${
+          notification.type === 'success'
+            ? 'bg-green-500'
+            : notification.type === 'error'
+            ? 'bg-red-500'
+            : 'bg-blue-500'
+        }`}
       >
-        {soundEnabled ? 'Mute sound' : 'Enable sound'}
-      </button>
-      <div role="status" aria-live="polite" aria-atomic="true">
-        {notifications.map(notification => (
-          <div
-            key={notification.id}
-            className={`px-4 py-2 rounded-lg shadow-lg text-white font-medium animate-slide-in animate-pulse ${
-              notification.type === 'success'
-                ? 'bg-green-500'
-                : notification.type === 'error'
-                ? 'bg-red-500'
-                : 'bg-blue-500'
-            }`}
-          >
-            {notification.message}
-          </div>
-        ))}
+        {notification.message}
       </div>
-    </div>
-  );
-};
+    ))}
+  </div>
+);
 
 Notifications.propTypes = {
   notifications: PropTypes.arrayOf(
@@ -91,7 +28,6 @@ Notifications.propTypes = {
       type: PropTypes.string.isRequired,
     })
   ).isRequired,
-  soundEnabled: PropTypes.bool,
 };
 
 export default Notifications;

--- a/src/components/__tests__/Notifications.test.jsx
+++ b/src/components/__tests__/Notifications.test.jsx
@@ -1,13 +1,9 @@
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import Notifications from '../Notifications.jsx';
 
 describe('Notifications', () => {
-  beforeEach(() => {
-    window.localStorage.clear();
-  });
-
-  test('renders notifications and live region', () => {
+  test('renders notifications', () => {
     const notifications = [
       { id: 1, message: 'Hello', type: 'success' },
       { id: 2, message: 'Error', type: 'error' }
@@ -15,15 +11,5 @@ describe('Notifications', () => {
     render(<Notifications notifications={notifications} />);
     expect(screen.getByText('Hello')).toBeInTheDocument();
     expect(screen.getByText('Error')).toBeInTheDocument();
-    expect(screen.getByRole('status')).toBeInTheDocument();
-  });
-
-  test('toggles sound preference', () => {
-    const notifications = [{ id: 1, message: 'Hello', type: 'success' }];
-    render(<Notifications notifications={notifications} />);
-    const button = screen.getByRole('button', { name: /mute sound/i });
-    fireEvent.click(button);
-    expect(screen.getByRole('button', { name: /enable sound/i })).toBeInTheDocument();
-    expect(window.localStorage.getItem('notificationSoundEnabled')).toBe('false');
   });
 });


### PR DESCRIPTION
## Summary
- strip audio and aria-live logic from Notifications so it simply renders messages
- archive original audio-enabled Notifications implementation
- update unit test to match simplified Notifications

## Testing
- `CI=true npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_689146a55b48832099b6f8c6ebc866b4