### PR TITLE
fix: stabilize crafting recipe helpers

### DIFF
--- a/src/features/CraftingPanel.jsx
+++ b/src/features/CraftingPanel.jsx
@@ -21,7 +21,7 @@ const CraftingPanel = ({
 }) => {
   const sortedRecipes = useMemo(
     () => sortRecipesByRarityAndCraftability(filterRecipesByType(craftingTab)),
-    [craftingTab, gameState.materials]
+    [craftingTab, gameState.materials, filterRecipesByType, sortRecipesByRarityAndCraftability]
   );
 
   const sortedInventory = useMemo(
@@ -33,7 +33,7 @@ const CraftingPanel = ({
           const recipeB = RECIPES.find(r => r.id === itemIdB);
           return compareRarities(recipeB.rarity, recipeA.rarity);
         }),
-    [inventoryTab, gameState.inventory]
+    [inventoryTab, gameState.inventory, filterInventoryByType]
   );
 
   return (

--- a/src/hooks/__tests__/gameLogic.test.js
+++ b/src/hooks/__tests__/gameLogic.test.js
@@ -1,3 +1,4 @@
+import { renderHook } from '@testing-library/react';
 import useCrafting from '../useCrafting';
 import useCustomers from '../useCustomers';
 import { setSeed } from '../../utils/random';
@@ -7,7 +8,8 @@ describe('core game logic', () => {
   test('openBox charges gold and yields deterministic materials', () => {
     let state1 = { gold: 100, materials: {}, inventory: {}, phase: PHASES.MORNING };
     const setState1 = (fn) => { state1 = typeof fn === 'function' ? fn(state1) : fn; };
-    const { openBox } = useCrafting(state1, setState1, jest.fn(), jest.fn());
+    const { result: result1 } = renderHook(() => useCrafting(state1, setState1, jest.fn(), jest.fn()));
+    const { openBox } = result1.current;
 
     setSeed(123);
     openBox('bronze');
@@ -17,7 +19,8 @@ describe('core game logic', () => {
 
     let state2 = { gold: 100, materials: {}, inventory: {}, phase: PHASES.MORNING };
     const setState2 = (fn) => { state2 = typeof fn === 'function' ? fn(state2) : fn; };
-    const { openBox: openBox2 } = useCrafting(state2, setState2, jest.fn(), jest.fn());
+    const { result: result2 } = renderHook(() => useCrafting(state2, setState2, jest.fn(), jest.fn()));
+    const { openBox: openBox2 } = result2.current;
 
     setSeed(123);
     openBox2('bronze');
@@ -29,7 +32,8 @@ describe('core game logic', () => {
   test('craftItem consumes materials and adds to inventory', () => {
     let state = { materials: { iron: 2, wood: 1 }, inventory: {}, gold: 0, phase: PHASES.CRAFTING };
     const setState = (fn) => { state = typeof fn === 'function' ? fn(state) : fn; };
-    const { craftItem } = useCrafting(state, setState, jest.fn(), jest.fn());
+    const { result } = renderHook(() => useCrafting(state, setState, jest.fn(), jest.fn()));
+    const { craftItem } = result.current;
 
     craftItem('iron_dagger');
 
@@ -40,7 +44,8 @@ describe('core game logic', () => {
   test('craftItem does nothing if materials are insufficient', () => {
     let state = { materials: { iron: 1 }, inventory: {}, gold: 0, phase: PHASES.CRAFTING };
     const setState = (fn) => { state = typeof fn === 'function' ? fn(state) : fn; };
-    const { craftItem } = useCrafting(state, setState, jest.fn(), jest.fn());
+    const { result } = renderHook(() => useCrafting(state, setState, jest.fn(), jest.fn()));
+    const { craftItem } = result.current;
 
     craftItem('iron_dagger');
 
@@ -65,7 +70,8 @@ describe('core game logic', () => {
   test('openBox does not spend gold if insufficient funds', () => {
     let state = { gold: 10, materials: {}, inventory: {}, phase: PHASES.MORNING };
     const setState = (fn) => { state = typeof fn === 'function' ? fn(state) : fn; };
-    const { openBox } = useCrafting(state, setState, jest.fn(), jest.fn());
+    const { result } = renderHook(() => useCrafting(state, setState, jest.fn(), jest.fn()));
+    const { openBox } = result.current;
 
     openBox('bronze');
 

--- a/src/hooks/__tests__/sortingHelpers.test.js
+++ b/src/hooks/__tests__/sortingHelpers.test.js
@@ -1,3 +1,4 @@
+import { renderHook } from '@testing-library/react';
 import useCrafting from '../useCrafting';
 import { RECIPES } from '../../constants';
 import { PHASES } from '../../constants';
@@ -5,29 +6,31 @@ import { PHASES } from '../../constants';
 describe('sorting helpers', () => {
   test('sortRecipesByRarityAndCraftability prioritizes craftable recipes and preserves input', () => {
     const state = { materials: { iron: 2, wood: 1 }, inventory: {}, phase: PHASES.CRAFTING };
-    const { sortRecipesByRarityAndCraftability } = useCrafting(state, () => {}, jest.fn(), jest.fn());
+    const { result: hookResult } = renderHook(() => useCrafting(state, () => {}, jest.fn(), jest.fn()));
+    const { sortRecipesByRarityAndCraftability } = hookResult.current;
     const recipes = RECIPES.filter(r => ['iron_dagger', 'iron_sword'].includes(r.id));
     const copy = [...recipes];
 
-    const result = sortRecipesByRarityAndCraftability(recipes);
+    const sorted = sortRecipesByRarityAndCraftability(recipes);
 
-    expect(result.map(r => r.id)).toEqual(['iron_dagger', 'iron_sword']);
+    expect(sorted.map(r => r.id)).toEqual(['iron_dagger', 'iron_sword']);
     expect(recipes).toEqual(copy);
   });
 
   test('sortByMatchQualityAndRarity respects customer preferences and preserves input', () => {
     const state = { materials: {}, inventory: {}, phase: PHASES.SHOPPING };
-    const { sortByMatchQualityAndRarity } = useCrafting(state, () => {}, jest.fn(), jest.fn());
+    const { result: hookResult } = renderHook(() => useCrafting(state, () => {}, jest.fn(), jest.fn()));
+    const { sortByMatchQualityAndRarity } = hookResult.current;
     const inventory = [ ['iron_dagger', 1], ['iron_sword', 1] ];
     const copy = [...inventory];
 
     const customer = { requestType: 'weapon', requestRarity: 'common', isFlexible: false, offerPrice: 0 };
 
-    const result = sortByMatchQualityAndRarity(inventory, customer);
-    expect(result[0][0]).toBe('iron_dagger');
+    const sorted = sortByMatchQualityAndRarity(inventory, customer);
+    expect(sorted[0][0]).toBe('iron_dagger');
     expect(inventory).toEqual(copy);
 
-    const resultNoCustomer = sortByMatchQualityAndRarity(inventory, null);
-    expect(resultNoCustomer[0][0]).toBe('iron_sword');
+    const sortedNoCustomer = sortByMatchQualityAndRarity(inventory, null);
+    expect(sortedNoCustomer[0][0]).toBe('iron_sword');
   });
 });

--- a/src/hooks/useCrafting.js
+++ b/src/hooks/useCrafting.js
@@ -1,3 +1,4 @@
+import { useCallback } from 'react';
 import { MATERIALS, RECIPES, BOX_TYPES } from '../constants';
 import { random } from '../utils/random';
 import { compareRarities } from '../utils/rarity';
@@ -69,30 +70,41 @@ const useCrafting = (gameState, setGameState, addEvent, addNotification) => {
     addNotification(`🔨 Successfully crafted ${recipe.name}!`, 'success');
   };
 
-  const canCraft = (recipe) => (
-    Object.entries(recipe.ingredients).every(([material, needed]) =>
-      (gameState.materials[material] || 0) >= needed
-    )
+  const canCraft = useCallback(
+    (recipe) =>
+      Object.entries(recipe.ingredients).every(([material, needed]) =>
+        (gameState.materials[material] || 0) >= needed
+      ),
+    [gameState.materials]
   );
 
-  const filterRecipesByType = (type) => RECIPES.filter(recipe => recipe.type === type);
+  const filterRecipesByType = useCallback(
+    (type) => RECIPES.filter(recipe => recipe.type === type),
+    []
+  );
 
-  const filterInventoryByType = (type) =>
-    Object.entries(gameState.inventory)
-      .filter(([_, count]) => count > 0)
-      .filter(([itemId]) => {
-        const recipe = RECIPES.find(r => r.id === itemId);
-        return recipe && recipe.type === type;
-      });
+  const filterInventoryByType = useCallback(
+    (type) =>
+      Object.entries(gameState.inventory)
+        .filter(([_, count]) => count > 0)
+        .filter(([itemId]) => {
+          const recipe = RECIPES.find(r => r.id === itemId);
+          return recipe && recipe.type === type;
+        }),
+    [gameState.inventory]
+  );
 
-  const sortRecipesByRarityAndCraftability = (recipes) =>
-    [...recipes].sort((a, b) => {
-      const canCraftA = canCraft(a);
-      const canCraftB = canCraft(b);
-      if (canCraftA && !canCraftB) return -1;
-      if (!canCraftA && canCraftB) return 1;
-      return compareRarities(b.rarity, a.rarity);
-    });
+  const sortRecipesByRarityAndCraftability = useCallback(
+    (recipes) =>
+      [...recipes].sort((a, b) => {
+        const canCraftA = canCraft(a);
+        const canCraftB = canCraft(b);
+        if (canCraftA && !canCraftB) return -1;
+        if (!canCraftA && canCraftB) return 1;
+        return compareRarities(b.rarity, a.rarity);
+      }),
+    [canCraft]
+  );
 
   const sortByMatchQualityAndRarity = (inventoryItems, customer) =>
     [...inventoryItems].sort((a, b) => {


### PR DESCRIPTION
## Summary
- add filter and sort helpers to CraftingPanel memo dependencies
- memoize recipe and inventory helpers with `useCallback`
- update tests to use `renderHook`

## Testing
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_68914a908d6883209207caf3fe031e53