### PR TITLE
Memoize inventory sorting

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { Package, Coins, ChevronRight, AlertCircle, ChevronDown, ChevronUp, Sun, Moon } from 'lucide-react';
 import { PHASES, MATERIALS, BOX_TYPES } from './constants';
 import EventLog from './components/EventLog';
@@ -93,11 +93,21 @@ const MerchantsMorning = () => {
     craftItem,
     canCraft,
     filterRecipesByType,
-    filterInventoryByType,
+    filterInventoryByType: rawFilterInventoryByType,
     sortRecipesByRarityAndCraftability,
-    sortByMatchQualityAndRarity,
+    sortByMatchQualityAndRarity: rawSortByMatchQualityAndRarity,
     getTopMaterials,
   } = useCrafting(gameState, setGameState, addEvent, addNotification);
+
+  const filterInventoryByType = useCallback(
+    (type) => rawFilterInventoryByType(type),
+    [gameState.inventory]
+  );
+
+  const sortByMatchQualityAndRarity = useCallback(
+    (items, customer) => rawSortByMatchQualityAndRarity(items, customer),
+    []
+  );
 
   const { openShop, serveCustomer, endDay, startNewDay } =
     useCustomers(gameState, setGameState, addEvent, addNotification, setSelectedCustomer);

--- a/src/features/ShopInterface.jsx
+++ b/src/features/ShopInterface.jsx
@@ -19,7 +19,13 @@ const ShopInterface = ({
 }) => {
   const sortedInventory = useMemo(
     () => sortByMatchQualityAndRarity(filterInventoryByType(sellingTab), selectedCustomer),
-    [sellingTab, selectedCustomer, gameState.inventory]
+    [
+      sellingTab,
+      selectedCustomer,
+      gameState.inventory,
+      filterInventoryByType,
+      sortByMatchQualityAndRarity,
+    ]
   );
 
   return (


### PR DESCRIPTION
## Summary
- include inventory filter and sort helpers in ShopInterface's memo deps
- memoize parent helpers with `useCallback` to stabilize references

## Testing
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_68914aa1dfb08320b6bc893e4ed3a54c