### PR TITLE
Refactor game persistence and UI labels

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -95,18 +95,13 @@ const MerchantsMorning = () => {
     filterRecipesByType,
     filterInventoryByType: rawFilterInventoryByType,
     sortRecipesByRarityAndCraftability,
-    sortByMatchQualityAndRarity: rawSortByMatchQualityAndRarity,
+    sortByMatchQualityAndRarity,
     getTopMaterials,
   } = useCrafting(gameState, setGameState, addEvent, addNotification);
 
   const filterInventoryByType = useCallback(
     (type) => rawFilterInventoryByType(type),
     [gameState.inventory]
-  );
-
-  const sortByMatchQualityAndRarity = useCallback(
-    (items, customer) => rawSortByMatchQualityAndRarity(items, customer),
-    []
   );
 
   const { openShop, serveCustomer, endDay, startNewDay } =
@@ -150,7 +145,7 @@ const MerchantsMorning = () => {
               }}
               className="flex items-center gap-1 text-xs bg-red-100 hover:bg-red-200 px-2 py-1 rounded dark:bg-red-700 dark:hover:bg-red-600"
             >
-              Reset
+              Reset Game
             </button>
           </div>
         </div>

--- a/src/components/Archived/NotificationsWithAudio.jsx
+++ b/src/components/Archived/NotificationsWithAudio.jsx
@@ -5,15 +5,23 @@ const Notifications = ({ notifications, soundEnabled: defaultSoundEnabled = true
   const audioCtxRef = useRef(null);
   const [soundEnabled, setSoundEnabled] = useState(() => {
     if (typeof window !== 'undefined') {
-      const stored = window.localStorage.getItem('notificationSoundEnabled');
-      if (stored !== null) return stored === 'true';
+      try {
+        const stored = window.localStorage.getItem('notificationSoundEnabled');
+        if (stored !== null) return stored === 'true';
+      } catch (e) {
+        console.error('Failed to load notification sound preference', e);
+      }
     }
     return defaultSoundEnabled;
   });
 
   useEffect(() => {
     if (typeof window !== 'undefined') {
-      window.localStorage.setItem('notificationSoundEnabled', soundEnabled);
+      try {
+        window.localStorage.setItem('notificationSoundEnabled', soundEnabled);
+      } catch (e) {
+        console.error('Failed to save notification sound preference', e);
+      }
     }
   }, [soundEnabled]);
 

--- a/src/hooks/useCrafting.js
+++ b/src/hooks/useCrafting.js
@@ -106,34 +106,37 @@ const useCrafting = (gameState, setGameState, addEvent, addNotification) => {
     [canCraft]
   );
 
-  const sortByMatchQualityAndRarity = (inventoryItems, customer) =>
-    [...inventoryItems].sort((a, b) => {
-      const recipeA = RECIPES.find(r => r.id === a[0]);
-      const recipeB = RECIPES.find(r => r.id === b[0]);
-      if (!customer) {
+  const sortByMatchQualityAndRarity = useCallback(
+    (inventoryItems, customer) =>
+      [...inventoryItems].sort((a, b) => {
+        const recipeA = RECIPES.find(r => r.id === a[0]);
+        const recipeB = RECIPES.find(r => r.id === b[0]);
+        if (!customer) {
+          return compareRarities(recipeB.rarity, recipeA.rarity);
+        }
+        const getMatchScore = (recipe) => {
+          const exactMatch = recipe.type === customer.requestType && recipe.rarity === customer.requestRarity;
+          if (exactMatch) return 4;
+          if (compareRarities(recipe.rarity, customer.requestRarity) > 0 && recipe.type === customer.requestType) {
+            return 3;
+          }
+          if (recipe.type === customer.requestType) {
+            return 2;
+          }
+          if (customer.isFlexible) {
+            return 1;
+          }
+          return 0;
+        };
+        const scoreA = getMatchScore(recipeA);
+        const scoreB = getMatchScore(recipeB);
+        if (scoreA !== scoreB) {
+          return scoreB - scoreA;
+        }
         return compareRarities(recipeB.rarity, recipeA.rarity);
-      }
-      const getMatchScore = (recipe) => {
-        const exactMatch = recipe.type === customer.requestType && recipe.rarity === customer.requestRarity;
-        if (exactMatch) return 4;
-        if (compareRarities(recipe.rarity, customer.requestRarity) > 0 && recipe.type === customer.requestType) {
-          return 3;
-        }
-        if (recipe.type === customer.requestType) {
-          return 2;
-        }
-        if (customer.isFlexible) {
-          return 1;
-        }
-        return 0;
-      };
-      const scoreA = getMatchScore(recipeA);
-      const scoreB = getMatchScore(recipeB);
-      if (scoreA !== scoreB) {
-        return scoreB - scoreA;
-      }
-      return compareRarities(recipeB.rarity, recipeA.rarity);
-    });
+      }),
+    []
+  );
 
   const getTopMaterials = () =>
     [...Object.entries(gameState.materials)]

--- a/src/hooks/useGamePersistence.js
+++ b/src/hooks/useGamePersistence.js
@@ -1,0 +1,40 @@
+import { useCallback } from 'react';
+
+const useGamePersistence = (key) => {
+  const loadState = useCallback(() => {
+    if (typeof window === 'undefined') return null;
+    try {
+      const saved = window.localStorage.getItem(key);
+      return saved ? JSON.parse(saved) : null;
+    } catch (e) {
+      console.error(`Failed to load ${key}`, e);
+      return null;
+    }
+  }, [key]);
+
+  const saveState = useCallback(
+    (state) => {
+      if (typeof window === 'undefined') return;
+      try {
+        window.localStorage.setItem(key, JSON.stringify(state));
+      } catch (e) {
+        console.error(`Failed to save ${key}`, e);
+      }
+    },
+    [key]
+  );
+
+  const clearState = useCallback(() => {
+    if (typeof window === 'undefined') return;
+    try {
+      window.localStorage.removeItem(key);
+    } catch (e) {
+      console.error(`Failed to clear ${key}`, e);
+    }
+  }, [key]);
+
+  return { loadState, saveState, clearState };
+};
+
+export default useGamePersistence;
+

--- a/src/hooks/useGameState.js
+++ b/src/hooks/useGameState.js
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import { PHASES } from '../constants';
+import useGamePersistence from './useGamePersistence';
 
 const INITIAL_GAME_STATE = {
   phase: PHASES.MORNING,
@@ -20,35 +21,17 @@ const INITIAL_GAME_STATE = {
 };
 
 const useGameState = () => {
-  const [gameState, setGameState] = useState(() => {
-    if (typeof window === 'undefined') return INITIAL_GAME_STATE;
-    try {
-      const saved = window.localStorage.getItem('gameState');
-      return saved ? JSON.parse(saved) : INITIAL_GAME_STATE;
-    } catch (e) {
-      console.error('Failed to load game state', e);
-      return INITIAL_GAME_STATE;
-    }
-  });
+  const { loadState, saveState, clearState } = useGamePersistence('gameState');
+
+  const [gameState, setGameState] = useState(() => loadState() || INITIAL_GAME_STATE);
 
   useEffect(() => {
-    if (typeof window === 'undefined') return;
-    try {
-      window.localStorage.setItem('gameState', JSON.stringify(gameState));
-    } catch (e) {
-      console.error('Failed to save game state', e);
-    }
-  }, [gameState]);
+    saveState(gameState);
+  }, [gameState, saveState]);
 
   const resetGame = () => {
     setGameState(INITIAL_GAME_STATE);
-    if (typeof window !== 'undefined') {
-      try {
-        window.localStorage.removeItem('gameState');
-      } catch (e) {
-        console.error('Failed to clear game state', e);
-      }
-    }
+    clearState();
   };
 
   return [gameState, setGameState, resetGame];


### PR DESCRIPTION
## Summary
- Rename Reset button to "Reset Game" for clarity
- Safely access localStorage in archived Notifications component
- Introduce reusable `useGamePersistence` hook and refactor `useGameState`
- Memoize `sortByMatchQualityAndRarity` with `useCallback`

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68915bd3877c8320840b7012bd21004e