### PR TITLE
Revamp customer pricing and budgets

### DIFF
--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -2,4 +2,4 @@ export { PHASES } from './phases';
 export { MATERIALS } from './materials';
 export { RECIPES } from './recipes';
 export { BOX_TYPES } from './boxes';
-export { ITEM_TYPES, RARITY_ORDER } from './items';
+export { ITEM_TYPES, RARITY_ORDER, BUDGET_TIERS } from './items';

--- a/src/constants/items.js
+++ b/src/constants/items.js
@@ -1,2 +1,3 @@
 export const ITEM_TYPES = ['weapon', 'armor', 'trinket'];
 export const RARITY_ORDER = { rare: 3, uncommon: 2, common: 1 };
+export const BUDGET_TIERS = ['budget', 'middle', 'wealthy'];

--- a/src/features/__tests__/ShopInterface.test.jsx
+++ b/src/features/__tests__/ShopInterface.test.jsx
@@ -12,6 +12,8 @@ describe('ShopInterface', () => {
       offerPrice: 10,
       satisfied: false,
       isFlexible: false,
+      budgetTier: 'middle',
+      maxBudget: 20,
     };
 
     const props = {
@@ -29,7 +31,7 @@ describe('ShopInterface', () => {
 
     const { rerender } = render(<ShopInterface {...props} />);
 
-    fireEvent.click(screen.getByText('Alice'));
+    fireEvent.click(screen.getByText('Alice', { exact: false }));
     expect(props.setSelectedCustomer).toHaveBeenCalledWith(customer);
     expect(props.setSellingTab).toHaveBeenCalledWith('weapon');
 


### PR DESCRIPTION
## Summary
- Introduce customer budget tiers with max spending limits and update UI to show tier icons and budgets
- Rework serveCustomer pricing: bonuses for higher rarity, penalties for downgrades, type mismatches, and budget enforcement
- Export new budget tier constants and extend tests for upgrades and affordability

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_6892068184d0832098640903ab3c39a8