### PR TITLE
Improve mobile layout and dark mode handling

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -108,13 +108,13 @@ const MerchantsMorning = () => {
     useCustomers(gameState, setGameState, addEvent, addNotification, setSelectedCustomer);
 
   return (
-    <div className="min-h-screen bg-gradient-to-b from-amber-50 to-orange-100 pb-16 dark:from-gray-900 dark:to-gray-800 dark:text-gray-100">
+    <div className="min-h-screen bg-gradient-to-b from-amber-50 to-orange-100 pb-20 pb-safe dark:from-gray-900 dark:to-gray-800 dark:text-gray-100">
       <Notifications notifications={notifications} />
       <div className="max-w-6xl mx-auto p-3">
         <div className="bg-white rounded-lg shadow-lg p-3 mb-3 flex items-center justify-between dark:bg-gray-800">
           <div>
             <h1 className="text-lg sm:text-xl font-bold text-amber-800 dark:text-amber-300">🏰 Merchant's Morning</h1>
-            <p className="text-xs text-amber-600 dark:text-amber-400">Day {gameState.day} • {gameState.phase.replace('_', ' ').toUpperCase()}</p>
+            <p className="text-sm sm:text-xs text-amber-600 dark:text-amber-400">Day {gameState.day} • {gameState.phase.replace('_', ' ').toUpperCase()}</p>
           </div>
           <div className="flex items-center gap-4">
             <div className="flex items-center gap-2 text-lg font-bold text-yellow-600">
@@ -130,7 +130,7 @@ const MerchantsMorning = () => {
             </button>
             <button
               onClick={() => setShowEventLog(!showEventLog)}
-              className="flex items-center gap-1 text-xs bg-gray-100 hover:bg-gray-200 px-2 py-1 rounded dark:bg-gray-700 dark:hover:bg-gray-600"
+              className="flex items-center gap-1 bg-gray-100 hover:bg-gray-200 px-2 py-1 rounded dark:bg-gray-700 dark:hover:bg-gray-600 text-sm sm:text-xs min-h-[44px] min-w-[44px]"
             >
               <AlertCircle className="w-3 h-3" />
               Events {showEventLog ? <ChevronUp className="w-3 h-3" /> : <ChevronDown className="w-3 h-3" />}
@@ -143,7 +143,7 @@ const MerchantsMorning = () => {
                   addNotification('Game reset', 'success');
                 }
               }}
-              className="flex items-center gap-1 text-xs bg-red-100 hover:bg-red-200 px-2 py-1 rounded dark:bg-red-700 dark:hover:bg-red-600"
+              className="flex items-center gap-1 bg-red-100 hover:bg-red-200 px-2 py-1 rounded dark:bg-red-700 dark:hover:bg-red-600 text-sm sm:text-xs min-h-[44px] min-w-[44px]"
             >
               Reset Game
             </button>
@@ -167,7 +167,7 @@ const MerchantsMorning = () => {
                 {Object.entries(BOX_TYPES).map(([type, box]) => (
                   <div key={type} className="border rounded-lg p-3 text-center hover:bg-gray-50 dark:border-gray-700 dark:hover:bg-gray-700">
                     <h3 className="font-bold capitalize text-sm mb-1">{box.name}</h3>
-                    <p className="text-xs text-gray-600 mb-2 dark:text-gray-300">
+                    <p className="text-sm sm:text-xs text-gray-600 mb-2 dark:text-gray-300">
                       {box.materialCount[0]}-{box.materialCount[1]} materials
                     </p>
                     <button
@@ -190,11 +190,11 @@ const MerchantsMorning = () => {
 
             <div className="bg-white rounded-lg shadow-lg p-4 dark:bg-gray-800">
               <h3 className="text-lg font-bold mb-3">Materials</h3>
-              <div className="grid grid-cols-2 gap-2">
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
                 {Object.entries(gameState.materials).filter(([_, count]) => count > 0).map(([materialId, count]) => {
                   const material = MATERIALS[materialId];
                   return (
-                    <div key={materialId} className={`p-2 rounded text-xs ${getRarityColor(material.rarity)}`}>
+                    <div key={materialId} className={`p-2 rounded text-sm sm:text-xs ${getRarityColor(material.rarity)}`}>
                       <span className="mr-1">{material.icon}</span>
                       {material.name}: {count}
                     </div>
@@ -242,7 +242,7 @@ const MerchantsMorning = () => {
         )}
       </div>
 
-      <div className="fixed bottom-0 left-0 right-0 bg-white border-t shadow-lg p-2 dark:bg-gray-800 dark:border-gray-700">
+      <div className="fixed bottom-0 left-0 right-0 bg-white border-t shadow-lg p-2 pb-safe dark:bg-gray-800 dark:border-gray-700">
         <div className="max-w-6xl mx-auto">
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-2 font-bold text-yellow-600">
@@ -253,14 +253,14 @@ const MerchantsMorning = () => {
               {getTopMaterials().map(([materialId, count]) => {
                 const material = MATERIALS[materialId];
                 return (
-                  <div key={materialId} className="flex items-center gap-1 text-xs whitespace-nowrap">
+                  <div key={materialId} className="flex items-center gap-1 text-sm sm:text-xs whitespace-nowrap">
                     <span>{material.icon}</span>
                     <span className="font-medium">{count}</span>
                   </div>
                 );
               })}
             </div>
-            <div className="text-xs text-gray-500 dark:text-gray-400">
+            <div className="text-sm sm:text-xs text-gray-500 dark:text-gray-400">
               Day {gameState.day}
             </div>
           </div>

--- a/src/components/EventLog.jsx
+++ b/src/components/EventLog.jsx
@@ -4,10 +4,10 @@ import PropTypes from 'prop-types';
 const EventLog = ({ events }) => (
   <div className="bg-gray-50 border rounded p-2 max-h-40 overflow-y-auto">
     {events.length === 0 ? (
-      <p className="text-gray-500 italic text-center py-8 text-xs">No events yet...</p>
+      <p className="text-gray-500 italic text-center py-8 text-sm sm:text-xs">No events yet...</p>
     ) : (
       events.map(event => (
-        <div key={event.id} className="text-xs mb-1">
+        <div key={event.id} className="text-sm sm:text-xs mb-1">
           <span
             className={
               event.type === 'success'

--- a/src/components/TabButton.jsx
+++ b/src/components/TabButton.jsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 const TabButton = ({ active, onClick, children, count }) => (
   <button
     onClick={onClick}
-    className={`px-4 py-2 rounded-lg whitespace-nowrap text-sm font-medium ${
+    className={`px-4 py-2 rounded-lg whitespace-nowrap font-medium min-h-[44px] min-w-[44px] text-sm sm:text-xs ${
       active
         ? 'bg-blue-500 text-white'
         : 'bg-gray-100 text-gray-600 hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600'

--- a/src/features/CraftingPanel.jsx
+++ b/src/features/CraftingPanel.jsx
@@ -44,7 +44,7 @@ const CraftingPanel = ({
         Crafting Workshop
       </h2>
 
-      <div className="flex gap-1 mb-3">
+      <div className="flex gap-1 mb-3 overflow-x-auto pb-1">
         {ITEM_TYPES.map(type => {
           const allRecipes = filterRecipesByType(type);
           const craftableCount = allRecipes.filter(canCraft).length;
@@ -74,15 +74,15 @@ const CraftingPanel = ({
           >
             <div className="flex justify-between items-start mb-1">
               <div className="flex-1">
-                <h4 className={`font-bold text-xs ${canCraft(recipe) ? 'text-black dark:text-white' : 'text-gray-500 dark:text-gray-400'}`}>{recipe.name}</h4>
-                <p className={`text-xs px-1 py-0.5 rounded inline-block mb-1 border ${getRarityColor(recipe.rarity)}`}>
+                <h4 className={`font-bold text-sm sm:text-xs ${canCraft(recipe) ? 'text-black dark:text-white' : 'text-gray-500 dark:text-gray-400'}`}>{recipe.name}</h4>
+                <p className={`text-sm sm:text-xs px-1 py-0.5 rounded inline-block mb-1 border ${getRarityColor(recipe.rarity)}`}>
                   {recipe.rarity}
                 </p>
               </div>
               <button
                 onClick={() => craftItem(recipe.id)}
                 disabled={!canCraft(recipe)}
-                className={`px-2 py-1 rounded text-xs font-bold ${
+                className={`px-2 py-1 rounded font-bold min-h-[44px] min-w-[44px] text-sm sm:text-xs ${
                   canCraft(recipe)
                     ? 'bg-blue-500 hover:bg-blue-600 text-white'
                     : 'bg-gray-200 text-gray-500 dark:bg-gray-700 dark:text-gray-400 cursor-not-allowed'
@@ -91,7 +91,7 @@ const CraftingPanel = ({
                 {canCraft(recipe) ? '✓ Craft' : '✗ Need Materials'}
               </button>
             </div>
-            <div className="text-xs text-gray-600 dark:text-gray-300">
+            <div className="text-sm sm:text-xs text-gray-600 dark:text-gray-300">
               {Object.entries(recipe.ingredients).map(([mat, count]) => {
                 const have = gameState.materials[mat] || 0;
                 const hasEnough = have >= count;
@@ -116,7 +116,7 @@ const CraftingPanel = ({
     <div className="bg-white rounded-lg shadow-lg p-4 dark:bg-gray-800">
       <h3 className="text-lg font-bold mb-3">Inventory</h3>
 
-      <div className="flex gap-1 mb-3">
+      <div className="flex gap-1 mb-3 overflow-x-auto pb-1">
         {ITEM_TYPES.map(type => {
           const count = filterInventoryByType(type).length;
           return (
@@ -136,14 +136,14 @@ const CraftingPanel = ({
         {sortedInventory.map(([itemId, count]) => {
             const recipe = RECIPES.find(r => r.id === itemId);
             return (
-              <div key={itemId} className={`p-2 rounded text-xs border ${getRarityColor(recipe.rarity)}`}>
+              <div key={itemId} className={`p-2 rounded text-sm sm:text-xs border ${getRarityColor(recipe.rarity)}`}>
                 <div className="font-bold">{recipe.name}</div>
                 <div className="text-gray-600 dark:text-gray-300">Stock: {count} • {recipe.sellPrice}g each</div>
               </div>
             );
           })}
         {sortedInventory.length === 0 && (
-          <p className="text-xs text-gray-500 italic dark:text-gray-400">No {inventoryTab}s crafted yet</p>
+          <p className="text-sm sm:text-xs text-gray-500 italic dark:text-gray-400">No {inventoryTab}s crafted yet</p>
         )}
       </div>
     </div>

--- a/src/features/EndOfDaySummary.jsx
+++ b/src/features/EndOfDaySummary.jsx
@@ -3,23 +3,23 @@ import PropTypes from 'prop-types';
 import { Star } from 'lucide-react';
 
 const EndOfDaySummary = ({ gameState, startNewDay }) => (
-  <div className="bg-white rounded-lg shadow-lg p-4 max-w-2xl mx-auto">
+  <div className="bg-white dark:bg-gray-800 rounded-lg shadow-lg p-4 max-w-2xl mx-auto">
     <h2 className="text-xl font-bold mb-4 flex items-center gap-2">
       <Star className="w-5 h-5" />
       Day {gameState.day} Complete!
     </h2>
 
-    <div className="grid grid-cols-2 gap-4 mb-6">
-      <div className="bg-green-100 p-3 rounded-lg text-center">
-        <h3 className="font-bold text-green-800 text-sm">Today's Earnings</h3>
-        <p className="text-lg font-bold text-green-600">
+    <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-6">
+      <div className="bg-green-100 dark:bg-green-900 p-3 rounded-lg text-center">
+        <h3 className="font-bold text-green-800 dark:text-green-200 text-sm">Today's Earnings</h3>
+        <p className="text-lg font-bold text-green-600 dark:text-green-200">
           {gameState.customers.reduce((total, c) => total + (c.payment || 0), 0)} Gold
         </p>
       </div>
 
-      <div className="bg-blue-100 p-3 rounded-lg text-center">
-        <h3 className="font-bold text-blue-800 text-sm">Customers Served</h3>
-        <p className="text-lg font-bold text-blue-600">
+      <div className="bg-blue-100 dark:bg-blue-900 p-3 rounded-lg text-center">
+        <h3 className="font-bold text-blue-800 dark:text-blue-200 text-sm">Customers Served</h3>
+        <p className="text-lg font-bold text-blue-600 dark:text-blue-200">
           {gameState.customers.filter(c => c.satisfied).length} / {gameState.customers.length}
         </p>
       </div>

--- a/src/features/ShopInterface.jsx
+++ b/src/features/ShopInterface.jsx
@@ -36,7 +36,28 @@ const ShopInterface = ({
         Select Customer ({gameState.customers.filter(c => !c.satisfied).length} waiting)
       </h2>
 
-      <div className="flex gap-2 overflow-x-auto pb-2">
+      <div className="sm:hidden mb-3">
+        <select
+          value={selectedCustomer?.id || ''}
+          onChange={(e) => {
+            const customer = gameState.customers.find(c => String(c.id) === e.target.value);
+            if (customer) {
+              setSelectedCustomer(customer);
+              setSellingTab(customer.requestType);
+            }
+          }}
+          className="w-full p-2 rounded-lg border bg-white dark:bg-gray-700 dark:text-gray-200 min-h-[44px]"
+        >
+          <option value="">Select a customer</option>
+          {gameState.customers.filter(c => !c.satisfied).map(c => (
+            <option key={c.id} value={c.id}>
+              {c.name} - {c.requestRarity} {c.requestType} ({c.maxBudget}g)
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <div className="hidden sm:flex gap-2 overflow-x-auto pb-2">
         {gameState.customers.filter(c => !c.satisfied).map(customer => (
           <button
             key={customer.id}
@@ -44,7 +65,7 @@ const ShopInterface = ({
               setSelectedCustomer(customer);
               setSellingTab(customer.requestType);
             }}
-            className={`px-4 py-2 rounded-lg whitespace-nowrap text-sm font-medium transition-colors ${
+            className={`px-4 py-2 rounded-lg whitespace-nowrap font-medium transition-colors min-h-[44px] min-w-[44px] text-sm sm:text-xs ${
               selectedCustomer?.id === customer.id
                 ? 'bg-blue-500 text-white'
                 : 'bg-gray-100 text-gray-700 hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600'
@@ -56,7 +77,7 @@ const ShopInterface = ({
               {customer.budgetTier === 'budget' && <span className="ml-1">🪙</span>}
               {customer.isFlexible && <span className="ml-1">😊</span>}
             </div>
-            <div className="text-xs opacity-80">
+            <div className="text-sm sm:text-xs opacity-80">
               {customer.requestRarity} {customer.requestType} • Budget: {customer.maxBudget}g
             </div>
           </button>
@@ -97,7 +118,7 @@ const ShopInterface = ({
         </p>
       )}
 
-      <div className="flex gap-1 mb-3">
+      <div className="flex gap-1 mb-3 overflow-x-auto pb-1">
         {ITEM_TYPES.map(type => {
           const count = filterInventoryByType(type).length;
           return (
@@ -191,16 +212,16 @@ const ShopInterface = ({
               <div className="flex justify-between items-start mb-2">
                 <div className="flex-1">
                   <h4 className="font-bold text-sm">{recipe.name}</h4>
-                  <p className={`text-xs px-1 py-0.5 rounded inline-block mb-1 border ${getRarityColor(recipe.rarity)}`}>
+                  <p className={`text-sm sm:text-xs px-1 py-0.5 rounded inline-block mb-1 border ${getRarityColor(recipe.rarity)}`}>
                     {recipe.type} • {recipe.rarity}
                   </p>
-                  <p className="text-xs text-gray-600 dark:text-gray-300">Stock: {count}</p>
+                  <p className="text-sm sm:text-xs text-gray-600 dark:text-gray-300">Stock: {count}</p>
                 </div>
               </div>
 
               {selectedCustomer && saleInfo && (
                 <div className="mb-2">
-                  <p className="text-xs font-bold">
+                  <p className="text-sm sm:text-xs font-bold">
                     {saleInfo.exactMatch ? (
                       <span className="text-green-600">✓ Perfect Match!</span>
                     ) : saleInfo.status === 'upgrade' ? (
@@ -241,7 +262,7 @@ const ShopInterface = ({
         {sortedInventory.length === 0 && (
           <div className="col-span-full text-center py-8">
             <p className="text-gray-500 italic dark:text-gray-400">No {sellingTab}s in stock</p>
-            <p className="text-xs text-gray-400 mt-1 dark:text-gray-500">Craft some items to sell!</p>
+            <p className="text-sm sm:text-xs text-gray-400 mt-1 dark:text-gray-500">Craft some items to sell!</p>
           </div>
         )}
       </div>

--- a/src/features/__tests__/ShopInterface.test.jsx
+++ b/src/features/__tests__/ShopInterface.test.jsx
@@ -31,7 +31,7 @@ describe('ShopInterface', () => {
 
     const { rerender } = render(<ShopInterface {...props} />);
 
-    fireEvent.click(screen.getByText('Alice', { exact: false }));
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: 'c1' } });
     expect(props.setSelectedCustomer).toHaveBeenCalledWith(customer);
     expect(props.setSellingTab).toHaveBeenCalledWith('weapon');
 

--- a/src/index.css
+++ b/src/index.css
@@ -132,6 +132,16 @@ button, .transition-colors {
   }
 }
 
+@layer utilities {
+  .min-touch {
+    min-width: 44px;
+    min-height: 44px;
+  }
+  .pb-safe {
+    padding-bottom: env(safe-area-inset-bottom);
+  }
+}
+
 /* Dark mode placeholder */
 @media (prefers-color-scheme: dark) {
   /* Add dark mode styles here if needed */


### PR DESCRIPTION
## Summary
- add mobile-friendly customer dropdown and larger touch targets
- make crafting and shopping views responsive with larger text on small screens
- implement dark mode styles for End of Day summary and add utility CSS for safe areas

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_689209fd85ac8320886e811c732d7fa7