### PR TITLE
Refactor UI layout and navigation

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
-import { Package, Coins, ChevronRight, AlertCircle, ChevronDown, ChevronUp, Sun, Moon, Menu } from 'lucide-react';
+import { Package, Coins, AlertCircle, Sun, Moon, Menu, BookOpen, Settings, HelpCircle } from 'lucide-react';
 import { PHASES, MATERIALS, BOX_TYPES } from './constants';
 import EventLog from './components/EventLog';
 import Notifications from './components/Notifications';
@@ -112,40 +112,42 @@ const MerchantsMorning = () => {
     <div className="min-h-screen bg-gradient-to-b from-amber-50 to-orange-100 pb-20 pb-safe dark:from-gray-900 dark:to-gray-800 dark:text-gray-100">
       <Notifications notifications={notifications} />
       <div className="max-w-6xl mx-auto p-3">
-        <div className="bg-white rounded-lg shadow-lg p-3 mb-3 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 dark:bg-gray-800">
-          <div>
-            <h1 className="text-lg sm:text-xl font-bold text-amber-800 dark:text-amber-300">🏰 Merchant's Morning</h1>
-            <p className="text-sm sm:text-xs text-amber-600 dark:text-amber-400">Day {gameState.day} • {gameState.phase.replace('_', ' ').toUpperCase()}</p>
-          </div>
-          <div className="flex items-center flex-wrap gap-2">
-            <div className="flex items-center gap-2 text-lg font-bold text-yellow-600">
-              <Coins className="w-4 h-4" />
-              {gameState.gold}
+        <div className="bg-white rounded-lg shadow-lg p-3 mb-3 dark:bg-gray-800">
+          <div className="flex items-start justify-between">
+            <div>
+              <h1 className="text-lg sm:text-xl font-bold text-amber-800 dark:text-amber-300">🏰 Merchant's Morning</h1>
+              <p className="text-sm sm:text-xs text-amber-600 dark:text-amber-400">Day {gameState.day} • {gameState.phase.replace('_', ' ').toUpperCase()}</p>
             </div>
-            <button
-              onClick={() => setShowEventLog(!showEventLog)}
-              className="w-10 h-10 flex items-center justify-center rounded bg-gray-100 hover:bg-gray-200 dark:bg-gray-700 dark:hover:bg-gray-600"
-              aria-label="Toggle event log"
-            >
-              {showEventLog ? <ChevronUp className="w-5 h-5" /> : <ChevronDown className="w-5 h-5" />}
-            </button>
-            <button
-              onClick={() => setDarkMode(!darkMode)}
-              className="w-10 h-10 flex items-center justify-center rounded bg-gray-100 hover:bg-gray-200 dark:bg-gray-700 dark:hover:bg-gray-600"
-              aria-label="Toggle dark mode"
-            >
-              {darkMode ? <Sun className="w-5 h-5 text-yellow-400" /> : <Moon className="w-5 h-5" />}
-            </button>
             <div className="relative">
               <button
                 onClick={() => setMenuOpen(!menuOpen)}
-                className="w-10 h-10 flex items-center justify-center rounded bg-gray-100 hover:bg-gray-200 dark:bg-gray-700 dark:hover:bg-gray-600"
+                className="w-12 h-12 flex items-center justify-center rounded bg-gray-100 hover:bg-gray-200 dark:bg-gray-700 dark:hover:bg-gray-600"
                 aria-label="Open menu"
               >
                 <Menu className="w-5 h-5" />
               </button>
               {menuOpen && (
-                <div className="absolute right-0 mt-2 w-40 bg-white border rounded shadow-lg dark:bg-gray-700 dark:border-gray-600">
+                <div className="absolute right-0 mt-2 w-48 bg-white border rounded shadow-lg dark:bg-gray-700 dark:border-gray-600">
+                  <button
+                    onClick={() => {
+                      setDarkMode(!darkMode);
+                      setMenuOpen(false);
+                    }}
+                    className="flex items-center gap-2 w-full px-4 py-2 text-sm hover:bg-gray-100 dark:hover:bg-gray-600"
+                  >
+                    {darkMode ? <Sun className="w-4 h-4 text-yellow-400" /> : <Moon className="w-4 h-4" />}
+                    {darkMode ? 'Light Mode' : 'Dark Mode'}
+                  </button>
+                  <button
+                    onClick={() => {
+                      setShowEventLog(!showEventLog);
+                      setMenuOpen(false);
+                    }}
+                    className="flex items-center gap-2 w-full px-4 py-2 text-sm hover:bg-gray-100 dark:hover:bg-gray-600"
+                  >
+                    <BookOpen className="w-4 h-4" />
+                    {showEventLog ? 'Hide Events' : 'Show Events'}
+                  </button>
                   <button
                     onClick={() => {
                       if (window.confirm('Reset game progress?')) {
@@ -160,9 +162,21 @@ const MerchantsMorning = () => {
                     <AlertCircle className="w-4 h-4" />
                     Reset Game
                   </button>
+                  <button disabled className="flex items-center gap-2 w-full px-4 py-2 text-sm text-gray-400 cursor-not-allowed">
+                    <Settings className="w-4 h-4" />
+                    Settings
+                  </button>
+                  <button disabled className="flex items-center gap-2 w-full px-4 py-2 text-sm text-gray-400 cursor-not-allowed">
+                    <HelpCircle className="w-4 h-4" />
+                    Help / About
+                  </button>
                 </div>
               )}
             </div>
+          </div>
+          <div className="mt-2 flex items-center gap-2 text-2xl font-bold text-yellow-600">
+            <Coins className="w-5 h-5" />
+            {gameState.gold}
           </div>
         </div>
 
@@ -196,12 +210,6 @@ const MerchantsMorning = () => {
                   </div>
                 ))}
               </div>
-              <button
-                onClick={() => setGameState(prev => ({ ...prev, phase: PHASES.CRAFTING }))}
-                className="w-full bg-green-500 hover:bg-green-600 text-white py-2 rounded-lg font-bold flex items-center justify-center gap-2"
-              >
-                Continue to Crafting <ChevronRight className="w-4 h-4" />
-              </button>
             </div>
 
             <div className="bg-white rounded-lg shadow-lg p-4 dark:bg-gray-800">
@@ -233,7 +241,6 @@ const MerchantsMorning = () => {
             filterRecipesByType={filterRecipesByType}
             sortRecipesByRarityAndCraftability={sortRecipesByRarityAndCraftability}
             filterInventoryByType={filterInventoryByType}
-            openShop={openShop}
             getRarityColor={getRarityColor}
           />
         )}
@@ -248,61 +255,68 @@ const MerchantsMorning = () => {
             filterInventoryByType={filterInventoryByType}
             sortByMatchQualityAndRarity={sortByMatchQualityAndRarity}
             serveCustomer={serveCustomer}
-            endDay={endDay}
             getRarityColor={getRarityColor}
           />
         )}
 
         {gameState.phase === PHASES.END_DAY && (
-          <EndOfDaySummary gameState={gameState} startNewDay={startNewDay} />
+          <EndOfDaySummary gameState={gameState} />
         )}
       </div>
 
-      <div className="fixed bottom-0 left-0 right-0 bg-white border-t shadow-lg p-3 pb-safe dark:bg-gray-800 dark:border-gray-700">
-        <div className="max-w-6xl mx-auto flex items-center justify-between gap-2">
-          <div className="flex items-center gap-2 font-bold text-yellow-600">
-            <Coins className="w-4 h-4" />
+      <div className="fixed bottom-0 left-0 right-0 bg-white border-t shadow-lg pb-safe dark:bg-gray-800 dark:border-gray-700">
+        <div className="max-w-6xl mx-auto flex items-center h-16">
+          <div className="flex items-center justify-center gap-1 w-20 text-xl font-bold text-yellow-600">
+            <Coins className="w-5 h-5" />
             {gameState.gold}
           </div>
-          <div className="flex items-center gap-2 overflow-x-auto flex-1 justify-center">
+          <div className="flex items-center gap-2 overflow-x-auto flex-1 px-4 border-l border-white/20 dark:border-white/20">
             {getTopMaterials().map(([materialId, count]) => {
               const material = MATERIALS[materialId];
               return (
-                <div key={materialId} className="flex items-center gap-1 text-sm sm:text-xs whitespace-nowrap">
+                <div key={materialId} className="flex items-center gap-1 text-base whitespace-nowrap">
                   <span>{material.icon}</span>
                   <span className="font-medium">{count}</span>
                 </div>
               );
             })}
           </div>
-          <div className="flex items-center gap-2">
-            <span className="text-sm sm:text-xs text-gray-500 dark:text-gray-400 whitespace-nowrap">
-              Day {gameState.day}
-            </span>
+          <div className="w-40 px-2 border-l border-white/20 dark:border-white/20">
             {gameState.phase === PHASES.MORNING && (
               <button
                 onClick={() => setGameState(prev => ({ ...prev, phase: PHASES.CRAFTING }))}
-                className="bg-green-500 hover:bg-green-600 text-white text-xs px-2 py-1 rounded"
+                className="w-full h-12 rounded font-bold text-white bg-green-500 hover:bg-green-600"
               >
-                Craft
+                START CRAFTING
               </button>
             )}
             {gameState.phase === PHASES.CRAFTING && (
               <button
                 onClick={openShop}
-                className="bg-blue-500 hover:bg-blue-600 text-white text-xs px-2 py-1 rounded"
+                className="w-full h-12 rounded font-bold text-white bg-blue-500 hover:bg-blue-600"
               >
-                Shop
+                OPEN SHOP
               </button>
             )}
             {gameState.phase === PHASES.SHOPPING && (
               <button
                 onClick={endDay}
-                className="bg-purple-500 hover:bg-purple-600 text-white text-xs px-2 py-1 rounded"
+                className="w-full h-12 rounded font-bold text-white bg-purple-500 hover:bg-purple-600"
               >
-                End
+                CLOSE SHOP
               </button>
             )}
+            {gameState.phase === PHASES.END_DAY && (
+              <button
+                onClick={startNewDay}
+                className="w-full h-12 rounded font-bold text-white bg-amber-500 hover:bg-amber-600"
+              >
+                NEW DAY
+              </button>
+            )}
+          </div>
+          <div className="w-20 text-center text-sm text-gray-500 border-l border-white/20 dark:border-white/20">
+            Day {gameState.day}
           </div>
         </div>
       </div>

--- a/src/components/TabButton.jsx
+++ b/src/components/TabButton.jsx
@@ -4,14 +4,18 @@ import PropTypes from 'prop-types';
 const TabButton = ({ active, onClick, children, count }) => (
   <button
     onClick={onClick}
-    className={`px-4 py-2 rounded-lg whitespace-nowrap font-medium min-h-[44px] min-w-[44px] text-sm sm:text-xs ${
+    className={`relative flex-1 flex items-center justify-center px-4 py-3 rounded-lg min-h-[48px] text-sm font-medium text-center whitespace-nowrap ${
       active
         ? 'bg-blue-500 text-white'
         : 'bg-gray-100 text-gray-600 hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600'
     }`}
   >
     {children}
-    {count !== undefined && count !== null && ` (${count})`}
+    {count !== undefined && count !== null && (
+      <span className="absolute top-1 right-1 text-[10px] px-1 rounded bg-blue-600 text-white">
+        {count}
+      </span>
+    )}
   </button>
 );
 

--- a/src/components/__tests__/TabButton.test.jsx
+++ b/src/components/__tests__/TabButton.test.jsx
@@ -9,7 +9,9 @@ describe('TabButton', () => {
         Weapons
       </TabButton>
     );
-    expect(screen.getByRole('button')).toHaveTextContent('Weapons (0)');
+    const button = screen.getByRole('button');
+    expect(button).toHaveTextContent('Weapons');
+    expect(button).toHaveTextContent('0');
   });
 
   test('hides count when not provided', () => {

--- a/src/features/CraftingPanel.jsx
+++ b/src/features/CraftingPanel.jsx
@@ -1,6 +1,6 @@
 import React, { useMemo } from 'react';
 import PropTypes from 'prop-types';
-import { Hammer, Store } from 'lucide-react';
+import { Hammer } from 'lucide-react';
 import { MATERIALS, RECIPES, ITEM_TYPES } from '../constants';
 import TabButton from '../components/TabButton';
 import { compareRarities } from '../utils/rarity';
@@ -16,7 +16,6 @@ const CraftingPanel = ({
   filterRecipesByType,
   sortRecipesByRarityAndCraftability,
   filterInventoryByType,
-  openShop,
   getRarityColor,
 }) => {
   const sortedRecipes = useMemo(
@@ -75,7 +74,7 @@ const CraftingPanel = ({
             <div className="flex justify-between items-start mb-1">
               <div className="flex-1">
                 <h4 className={`font-bold text-sm sm:text-xs ${canCraft(recipe) ? 'text-black dark:text-white' : 'text-gray-500 dark:text-gray-400'}`}>{recipe.name}</h4>
-                <p className={`text-sm sm:text-xs px-1 py-0.5 rounded inline-block mb-1 border ${getRarityColor(recipe.rarity)}`}>
+                <p className={`text-sm px-1 py-0.5 rounded inline-block mb-1 border ${getRarityColor(recipe.rarity)}`}>
                   {recipe.rarity}
                 </p>
               </div>
@@ -91,13 +90,13 @@ const CraftingPanel = ({
                 {canCraft(recipe) ? '✓ Craft' : '✗ Need Materials'}
               </button>
             </div>
-            <div className="text-sm sm:text-xs text-gray-600 dark:text-gray-300">
+            <div className="flex flex-wrap gap-3 text-sm sm:text-xs text-gray-600 dark:text-gray-300">
               {Object.entries(recipe.ingredients).map(([mat, count]) => {
                 const have = gameState.materials[mat] || 0;
                 const hasEnough = have >= count;
                 return (
-                  <span key={mat} className={`mr-2 ${hasEnough ? 'text-green-600' : 'text-red-600'}`}>
-                    {MATERIALS[mat].icon}{count}({have})
+                  <span key={mat} className={`${hasEnough ? 'text-green-600' : 'text-red-600'}`}>
+                    {MATERIALS[mat].icon} {count}/{have}
                   </span>
                 );
               })}
@@ -105,12 +104,6 @@ const CraftingPanel = ({
           </div>
         ))}
       </div>
-      <button
-        onClick={openShop}
-        className="w-full bg-green-500 hover:bg-green-600 text-white py-2 rounded-lg font-bold flex items-center justify-center gap-2"
-      >
-        Open Shop <Store className="w-4 h-4" />
-      </button>
     </div>
 
     <div className="bg-white rounded-lg shadow-lg p-4 dark:bg-gray-800">
@@ -165,7 +158,6 @@ CraftingPanel.propTypes = {
   filterRecipesByType: PropTypes.func.isRequired,
   sortRecipesByRarityAndCraftability: PropTypes.func.isRequired,
   filterInventoryByType: PropTypes.func.isRequired,
-  openShop: PropTypes.func.isRequired,
   getRarityColor: PropTypes.func.isRequired,
 };
 

--- a/src/features/EndOfDaySummary.jsx
+++ b/src/features/EndOfDaySummary.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Star } from 'lucide-react';
 
-const EndOfDaySummary = ({ gameState, startNewDay }) => (
+const EndOfDaySummary = ({ gameState }) => (
   <div className="bg-white dark:bg-gray-800 rounded-lg shadow-lg p-4 max-w-2xl mx-auto">
     <h2 className="text-xl font-bold mb-4 flex items-center gap-2">
       <Star className="w-5 h-5" />
@@ -25,12 +25,6 @@ const EndOfDaySummary = ({ gameState, startNewDay }) => (
       </div>
     </div>
 
-    <button
-      onClick={startNewDay}
-      className="w-full bg-amber-500 hover:bg-amber-600 text-white py-3 rounded-lg font-bold text-lg"
-    >
-      Start Day {gameState.day + 1}
-    </button>
   </div>
 );
 
@@ -44,7 +38,6 @@ EndOfDaySummary.propTypes = {
       })
     ).isRequired,
   }).isRequired,
-  startNewDay: PropTypes.func.isRequired,
 };
 
 export default EndOfDaySummary;

--- a/src/features/ShopInterface.jsx
+++ b/src/features/ShopInterface.jsx
@@ -14,7 +14,6 @@ const ShopInterface = ({
   filterInventoryByType,
   sortByMatchQualityAndRarity,
   serveCustomer,
-  endDay,
   getRarityColor,
 }) => {
   const sortedInventory = useMemo(
@@ -91,13 +90,6 @@ const ShopInterface = ({
           </p>
         </div>
       )}
-
-      <button
-        onClick={endDay}
-        className="w-full mt-4 bg-orange-500 hover:bg-orange-600 text-white py-2 rounded-lg font-bold"
-      >
-        Close Shop for Today
-      </button>
     </div>
 
     {selectedCustomer && (
@@ -294,7 +286,6 @@ ShopInterface.propTypes = {
   filterInventoryByType: PropTypes.func.isRequired,
   sortByMatchQualityAndRarity: PropTypes.func.isRequired,
   serveCustomer: PropTypes.func.isRequired,
-  endDay: PropTypes.func.isRequired,
   getRarityColor: PropTypes.func.isRequired,
 };
 

--- a/src/features/__tests__/CraftingPanel.test.jsx
+++ b/src/features/__tests__/CraftingPanel.test.jsx
@@ -3,7 +3,7 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import CraftingPanel from '../CraftingPanel.jsx';
 
 describe('CraftingPanel', () => {
-  test('renders recipes and handles crafting and shop opening', () => {
+  test('renders recipes and handles crafting', () => {
     const gameState = { materials: {}, inventory: {} };
     const recipe = { id: 'r1', name: 'Test Item', ingredients: {}, rarity: 'common' };
 
@@ -18,7 +18,6 @@ describe('CraftingPanel', () => {
       filterRecipesByType: jest.fn(() => [recipe]),
       sortRecipesByRarityAndCraftability: jest.fn(recipes => recipes),
       filterInventoryByType: jest.fn(() => []),
-      openShop: jest.fn(),
       getRarityColor: jest.fn(() => 'border-gray-200'),
     };
 
@@ -28,7 +27,5 @@ describe('CraftingPanel', () => {
     fireEvent.click(screen.getByText('✓ Craft'));
     expect(props.craftItem).toHaveBeenCalledWith('r1');
 
-    fireEvent.click(screen.getByText(/Open Shop/));
-    expect(props.openShop).toHaveBeenCalled();
   });
 });

--- a/src/features/__tests__/EndOfDaySummary.test.jsx
+++ b/src/features/__tests__/EndOfDaySummary.test.jsx
@@ -1,9 +1,9 @@
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import EndOfDaySummary from '../EndOfDaySummary.jsx';
 
 describe('EndOfDaySummary', () => {
-  test('shows summary and starts new day', () => {
+  test('shows summary', () => {
     const gameState = {
       day: 1,
       customers: [
@@ -11,15 +11,10 @@ describe('EndOfDaySummary', () => {
         { payment: 0, satisfied: false },
       ],
     };
-    const startNewDay = jest.fn();
-
-    render(<EndOfDaySummary gameState={gameState} startNewDay={startNewDay} />);
+    render(<EndOfDaySummary gameState={gameState} />);
 
     expect(screen.getByText('Day 1 Complete!')).toBeInTheDocument();
     expect(screen.getByText('5 Gold')).toBeInTheDocument();
     expect(screen.getByText('1 / 2')).toBeInTheDocument();
-
-    fireEvent.click(screen.getByText('Start Day 2'));
-    expect(startNewDay).toHaveBeenCalled();
   });
 });

--- a/src/features/__tests__/ShopInterface.test.jsx
+++ b/src/features/__tests__/ShopInterface.test.jsx
@@ -25,7 +25,6 @@ describe('ShopInterface', () => {
       filterInventoryByType: jest.fn(() => [['iron_dagger', 1]]),
       sortByMatchQualityAndRarity: jest.fn(items => items),
       serveCustomer: jest.fn(),
-      endDay: jest.fn(),
       getRarityColor: jest.fn(() => 'border-gray-200'),
     };
 
@@ -39,8 +38,5 @@ describe('ShopInterface', () => {
 
     fireEvent.click(screen.getByText('Sell to Alice'));
     expect(props.serveCustomer).toHaveBeenCalledWith('c1', 'iron_dagger');
-
-    fireEvent.click(screen.getByText('Close Shop for Today'));
-    expect(props.endDay).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- Redesign header into two rows with a hamburger menu controlling dark mode, event log visibility, and future options
- Simplify page flow by removing in-content phase buttons and moving actions to a new bottom navigation bar
- Improve tab styling and ingredient clarity with centered labels, count badges, and needed/available fractions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689213b7ab508320b62e17d663f3a5d7