### PR TITLE
Disallow cross-category sales and rebalance budgets

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -7,7 +7,7 @@ A fantasy shopkeeping Progressive Web App where you craft items from materials a
 - **Daily Loop Gameplay**: Buy supplies → Craft items → Serve customers → Earn gold
 - **Progressive Difficulty**: Customers want more valuable items as days progress
 - **Smart Crafting System**: Tabbed interface with rarity-based sorting
-- **Strategic Selling**: Match customer requests or offer substitutes
+- **Strategic Selling**: Match customer requests and earn bonuses for upgrades
 - **PWA Ready**: Install on mobile/desktop, works offline
 
 ## 🚀 Quick Setup
@@ -55,7 +55,7 @@ A fantasy shopkeeping Progressive Web App where you craft items from materials a
 - Select customers from horizontal tabs
 - Auto-switches to relevant product category
 - Perfect matches = full payment
-- Substitutes = reduced payment (except to flexible customers 😊)
+- Wrong item types cannot be sold
 
 ### End of Day
 - Review earnings and customer satisfaction

--- a/src/features/ShopInterface.jsx
+++ b/src/features/ShopInterface.jsx
@@ -74,7 +74,6 @@ const ShopInterface = ({
               {customer.name}
               {customer.budgetTier === 'wealthy' && <span className="ml-1">💰</span>}
               {customer.budgetTier === 'budget' && <span className="ml-1">🪙</span>}
-              {customer.isFlexible && <span className="ml-1">😊</span>}
             </div>
             <div className="text-sm sm:text-xs opacity-80">
               {customer.requestRarity} {customer.requestType} • Budget: {customer.maxBudget}g
@@ -96,7 +95,6 @@ const ShopInterface = ({
       <div className="bg-blue-50 p-3 rounded-lg border border-blue-200 dark:bg-blue-900 dark:border-blue-700">
         <p className="font-medium text-blue-800 dark:text-blue-300">
           Selling to: {selectedCustomer.name} (wants {selectedCustomer.requestRarity} {selectedCustomer.requestType} • Budget: {selectedCustomer.maxBudget}g)
-          {selectedCustomer.isFlexible && <span className="text-blue-600"> • Flexible with substitutes 😊</span>}
         </p>
         <p className="text-sm text-blue-700 dark:text-blue-300">
           Prefers: {
@@ -155,7 +153,6 @@ const ShopInterface = ({
             } else if (
               saleInfo.status === 'downgrade' ||
               saleInfo.status === 'wrong_rarity' ||
-              saleInfo.status === 'substitute' ||
               saleInfo.status === 'over_budget' ||
               saleInfo.status === 'wrong_type'
             ) {
@@ -189,10 +186,8 @@ const ShopInterface = ({
                       <span className="text-blue-600">⬆️ Upgrade!</span>
                     ) : saleInfo.status === 'downgrade' ? (
                       <span className="text-yellow-600">⬇️ Downgrade</span>
-                    ) : saleInfo.status === 'substitute' ? (
-                      <span className="text-yellow-600">~ Acceptable substitute</span>
                     ) : saleInfo.status === 'wrong_type' ? (
-                      <span className="text-red-600">~ Poor substitute</span>
+                      <span className="text-red-600">❌ Wrong item type</span>
                     ) : saleInfo.status === 'cant_afford' ? (
                       <span className="text-red-600">❌ Too expensive</span>
                     ) : saleInfo.status === 'over_budget' ? (
@@ -247,7 +242,6 @@ ShopInterface.propTypes = {
     budgetTier: PropTypes.string.isRequired,
     maxBudget: PropTypes.number.isRequired,
     satisfied: PropTypes.bool,
-    isFlexible: PropTypes.bool,
     payment: PropTypes.number,
   }),
   setSelectedCustomer: PropTypes.func.isRequired,

--- a/src/hooks/__tests__/sortingHelpers.test.js
+++ b/src/hooks/__tests__/sortingHelpers.test.js
@@ -24,7 +24,7 @@ describe('sorting helpers', () => {
     const inventory = [ ['iron_dagger', 1], ['iron_sword', 1] ];
     const copy = [...inventory];
 
-    const customer = { requestType: 'weapon', requestRarity: 'common', isFlexible: false, offerPrice: 0, profession: 'ranger' };
+    const customer = { requestType: 'weapon', requestRarity: 'common', offerPrice: 0, profession: 'ranger' };
 
     const sorted = sortByMatchQualityAndRarity(inventory, customer);
     expect(sorted[0][0]).toBe('iron_dagger');


### PR DESCRIPTION
## Summary
- Block sales when item type doesn't match the customer's request and adjust UI messaging
- Rebalance customer budgets: wealthier payouts and fewer budget shoppers
- Clarify sale info so wrong-type items stay affordable and add coverage tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689225f1b334832083c593064843e897