### PR TITLE
Show gazette during crafting and fix menu overlap

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -128,7 +128,7 @@ const MerchantsMorning = () => {
                 <Menu className="w-5 h-5" />
               </button>
               {menuOpen && (
-                <div className="absolute right-0 mt-2 w-48 bg-white border rounded shadow-lg dark:bg-gray-700 dark:border-gray-600">
+                <div className="absolute right-0 mt-2 w-48 bg-white border rounded shadow-lg dark:bg-gray-700 dark:border-gray-600 z-50">
                   <button
                     onClick={() => {
                       setDarkMode(!darkMode);
@@ -186,27 +186,28 @@ const MerchantsMorning = () => {
             <EventLog events={eventLog} />
           </div>
         )}
+        {[PHASES.MORNING, PHASES.CRAFTING].includes(gameState.phase) && (
+          <div className="bg-white rounded-lg shadow-lg p-4 mb-3 dark:bg-gray-800">
+            <h2 className="text-lg font-bold mb-3 flex items-center gap-2">
+              <BookOpen className="w-4 h-4" />
+              Morning Gazette
+            </h2>
+            {gameState.marketReports.length > 0 ? (
+              <ul className="list-disc pl-5 space-y-1 text-sm">
+                {gameState.marketReports.map((report, idx) => (
+                  <li key={idx}>{report}</li>
+                ))}
+              </ul>
+            ) : (
+              <p className="text-sm italic text-gray-600 dark:text-gray-300">
+                The market is quiet today.
+              </p>
+            )}
+          </div>
+        )}
 
         {gameState.phase === PHASES.MORNING && (
           <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
-            <div className="lg:col-span-3 bg-white rounded-lg shadow-lg p-4 dark:bg-gray-800">
-              <h2 className="text-lg font-bold mb-3 flex items-center gap-2">
-                <BookOpen className="w-4 h-4" />
-                Morning Gazette
-              </h2>
-              {gameState.marketReports.length > 0 ? (
-                <ul className="list-disc pl-5 space-y-1 text-sm">
-                  {gameState.marketReports.map((report, idx) => (
-                    <li key={idx}>{report}</li>
-                  ))}
-                </ul>
-              ) : (
-                <p className="text-sm italic text-gray-600 dark:text-gray-300">
-                  The market is quiet today.
-                </p>
-              )}
-            </div>
-
             <div className="lg:col-span-2 bg-white rounded-lg shadow-lg p-4 dark:bg-gray-800">
               <h2 className="text-lg font-bold mb-3 flex items-center gap-2">
                 <Package className="w-4 h-4" />


### PR DESCRIPTION
## Summary
- Keep Morning Gazette visible during crafting phase
- Ensure hamburger menu overlays crafting tabs

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_689230a5ed208320bb5788d30a186d36