### PR TITLE
Enhance phase transition feedback

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,6 +3,7 @@ import { Package, Coins, AlertCircle, Sun, Moon, Menu, BookOpen, Settings, HelpC
 import { PHASES, MATERIALS, BOX_TYPES } from './constants';
 import EventLog from './components/EventLog';
 import Notifications from './components/Notifications';
+import Button from './components/Button';
 import useCrafting from './hooks/useCrafting';
 import useCustomers from './hooks/useCustomers';
 import useGameState from './hooks/useGameState';
@@ -300,36 +301,40 @@ const MerchantsMorning = () => {
           </div>
           <div className="flex-[3] px-4 border-l border-gray-400/30 dark:border-white/20 flex items-center">
             {gameState.phase === PHASES.MORNING && (
-              <button
-                onClick={() => setGameState(prev => ({ ...prev, phase: PHASES.CRAFTING }))}
+              <Button
+                onClick={() => {
+                  setGameState(prev => ({ ...prev, phase: PHASES.CRAFTING }));
+                  addEvent('Crafting phase started', 'info');
+                  addNotification('⚒️ Crafting phase started', 'info');
+                }}
                 className="w-full h-12 rounded-lg font-bold text-white bg-green-500 hover:bg-green-600 shadow"
               >
                 START CRAFTING
-              </button>
+              </Button>
             )}
             {gameState.phase === PHASES.CRAFTING && (
-              <button
+              <Button
                 onClick={openShop}
                 className="w-full h-12 rounded-lg font-bold text-white bg-blue-500 hover:bg-blue-600 shadow"
               >
                 OPEN SHOP
-              </button>
+              </Button>
             )}
             {gameState.phase === PHASES.SHOPPING && (
-              <button
+              <Button
                 onClick={endDay}
                 className="w-full h-12 rounded-lg font-bold text-white bg-purple-500 hover:bg-purple-600 shadow"
               >
                 CLOSE SHOP
-              </button>
+              </Button>
             )}
             {gameState.phase === PHASES.END_DAY && (
-              <button
+              <Button
                 onClick={startNewDay}
                 className="w-full h-12 rounded-lg font-bold text-white bg-amber-500 hover:bg-amber-600 shadow"
               >
                 NEW DAY
-              </button>
+              </Button>
             )}
           </div>
         </div>

--- a/src/components/Button.jsx
+++ b/src/components/Button.jsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const Button = ({ className = '', children, ...props }) => (
+  <button
+    className={`transition transform active:scale-95 focus:outline-none focus:ring-2 focus:ring-offset-2 ${className}`}
+    {...props}
+  >
+    {children}
+  </button>
+);
+
+Button.propTypes = {
+  className: PropTypes.string,
+  children: PropTypes.node.isRequired,
+};
+
+export default Button;

--- a/src/hooks/__tests__/gameLogic.test.js
+++ b/src/hooks/__tests__/gameLogic.test.js
@@ -57,7 +57,8 @@ describe('core game logic', () => {
     let state = { phase: PHASES.END_DAY, day: 1, customers: [{ id: '1' }], inventory: {}, gold: 0, totalEarnings: 0 };
     const setState = (fn) => { state = typeof fn === 'function' ? fn(state) : fn; };
     const setSelectedCustomer = jest.fn();
-    const { startNewDay } = useCustomers(state, setState, jest.fn(), jest.fn(), setSelectedCustomer);
+    const addNotification = jest.fn();
+    const { startNewDay } = useCustomers(state, setState, jest.fn(), addNotification, setSelectedCustomer);
 
     startNewDay();
 
@@ -65,6 +66,7 @@ describe('core game logic', () => {
     expect(state.phase).toBe(PHASES.MORNING);
     expect(state.customers).toEqual([]);
     expect(setSelectedCustomer).toHaveBeenCalledWith(null);
+    expect(addNotification).toHaveBeenCalled();
   });
 
   test('openBox does not spend gold if insufficient funds', () => {

--- a/src/hooks/useCustomers.js
+++ b/src/hooks/useCustomers.js
@@ -128,6 +128,7 @@ const useCustomers = (gameState, setGameState, addEvent, addNotification, setSel
       customers
     }));
     addEvent(`Shop opened with ${customers.length} customers waiting`, 'info');
+    addNotification('🛒 Shop opened', 'info');
   };
 
   const serveCustomer = (customerId, itemId, action = 'sell') => {
@@ -247,6 +248,8 @@ const useCustomers = (gameState, setGameState, addEvent, addNotification, setSel
       ...prev,
       phase: PHASES.END_DAY
     }));
+    addEvent('Shop closed for the day', 'info');
+    addNotification('🏁 Shop closed for the day', 'info');
   };
 
   const startNewDay = () => {
@@ -259,7 +262,9 @@ const useCustomers = (gameState, setGameState, addEvent, addNotification, setSel
       marketReports: reports,
       marketBias: bias,
     }));
-    addEvent(`Started Day ${gameState.day + 1}`, 'info');
+    const nextDay = gameState.day + 1;
+    addEvent(`Started Day ${nextDay}`, 'info');
+    addNotification(`🌅 Started Day ${nextDay}`, 'info');
     setSelectedCustomer(null);
   };
 


### PR DESCRIPTION
## Summary
- add reusable Button with press animation
- show notifications/events when advancing to a new phase
- test that starting a new day triggers a notification

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_689286a04d488320b240ee2507ca57ed