### PR TITLE
Restore platinum and diamond supply boxes

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -43,7 +43,7 @@ A fantasy shopkeeping Progressive Web App where you craft items from materials a
 
 ### Morning Phase
 - Buy supply boxes with gold
-- Bronze/Silver/Gold/Mythic boxes give different material rarities
+- Bronze/Silver/Gold/Platinum/Diamond/Mythic boxes give different material rarities
 - Higher tier boxes cost more but give better materials
 
 ### Crafting Phase

--- a/src/constants/boxes.js
+++ b/src/constants/boxes.js
@@ -17,6 +17,18 @@ export const BOX_TYPES = {
     materialCount: [6, 8],
     rarityWeights: { common: 25, uncommon: 60, rare: 15 },
   },
+  platinum: {
+    name: 'Platinum Box',
+    cost: 140,
+    materialCount: [7, 10],
+    rarityWeights: { common: 15, uncommon: 55, rare: 30 },
+  },
+  diamond: {
+    name: 'Diamond Box',
+    cost: 200,
+    materialCount: [8, 11],
+    rarityWeights: { common: 10, uncommon: 50, rare: 40 },
+  },
   mythic: {
     name: 'Mythic Box',
     cost: 300,


### PR DESCRIPTION
## Summary
- Reintroduce Platinum and Diamond supply boxes so players can open high-tier crates again
- Document all box tiers in README

## Testing
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_68935c871dd483208bf45013ac2413d8