### PR TITLE
feat: add collapsible card layout

### DIFF
--- a/src/components/Card.jsx
+++ b/src/components/Card.jsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+export const Card = ({ children }) => (
+  <div className="bg-white rounded-lg shadow-lg mb-3 dark:bg-gray-800">
+    {children}
+  </div>
+);
+
+Card.propTypes = {
+  children: PropTypes.node.isRequired,
+};
+
+export const CardHeader = ({ icon, title, subtitle, expanded, onToggle, isEmpty, subtitleClassName = '' }) => (
+  <button
+    onClick={onToggle}
+    className={`w-full flex items-center justify-between p-4 text-left ${isEmpty ? 'opacity-60' : ''}`}
+    aria-expanded={expanded}
+  >
+    <div className="flex items-center gap-2">
+      <span className="text-lg" aria-hidden="true">{icon}</span>
+      <span className="font-bold">{title}</span>
+    </div>
+    {subtitle && (
+      <span className={`text-sm ${subtitleClassName}`}>{subtitle}</span>
+    )}
+  </button>
+);
+
+CardHeader.propTypes = {
+  icon: PropTypes.node.isRequired,
+  title: PropTypes.string.isRequired,
+  subtitle: PropTypes.string,
+  expanded: PropTypes.bool,
+  onToggle: PropTypes.func.isRequired,
+  isEmpty: PropTypes.bool,
+  subtitleClassName: PropTypes.string,
+};
+
+export const CardContent = ({ children }) => (
+  <div className="p-4 border-t border-gray-200 dark:border-gray-700">
+    {children}
+  </div>
+);
+
+CardContent.propTypes = {
+  children: PropTypes.node.isRequired,
+};
+
+export default Card;

--- a/src/features/InventoryPanel.jsx
+++ b/src/features/InventoryPanel.jsx
@@ -1,0 +1,71 @@
+import React, { useMemo } from 'react';
+import PropTypes from 'prop-types';
+import TabButton from '../components/TabButton';
+import { RECIPES, ITEM_TYPES } from '../constants';
+
+const InventoryPanel = ({
+  gameState,
+  inventoryTab,
+  setInventoryTab,
+  filterInventoryByType,
+  getRarityColor,
+}) => {
+  const sortedInventory = useMemo(
+    () =>
+      filterInventoryByType(inventoryTab)
+        .slice()
+        .sort(([itemIdA], [itemIdB]) => {
+          const recipeA = RECIPES.find(r => r.id === itemIdA);
+          const recipeB = RECIPES.find(r => r.id === itemIdB);
+          return recipeB.rarity.localeCompare(recipeA.rarity);
+        }),
+    [inventoryTab, gameState.inventory, filterInventoryByType]
+  );
+
+  return (
+    <div>
+      <div className="flex gap-1 mb-3 overflow-x-auto pb-1">
+        {ITEM_TYPES.map(type => {
+          const count = filterInventoryByType(type).length;
+          return (
+            <TabButton
+              key={type}
+              active={inventoryTab === type}
+              onClick={() => setInventoryTab(type)}
+              count={count}
+            >
+              {type.charAt(0).toUpperCase() + type.slice(1)}
+            </TabButton>
+          );
+        })}
+      </div>
+
+      <div className="space-y-2 max-h-80 overflow-y-auto">
+        {sortedInventory.map(([itemId, count]) => {
+          const recipe = RECIPES.find(r => r.id === itemId);
+          return (
+            <div key={itemId} className={`p-2 rounded text-sm sm:text-xs border ${getRarityColor(recipe.rarity)}`}>
+              <div className="font-bold">{recipe.name}</div>
+              <div className="text-gray-600 dark:text-gray-300">Stock: {count} • {recipe.sellPrice}g each</div>
+            </div>
+          );
+        })}
+        {sortedInventory.length === 0 && (
+          <p className="text-sm sm:text-xs text-gray-500 italic dark:text-gray-400">No {inventoryTab}s crafted yet</p>
+        )}
+      </div>
+    </div>
+  );
+};
+
+InventoryPanel.propTypes = {
+  gameState: PropTypes.shape({
+    inventory: PropTypes.object.isRequired,
+  }).isRequired,
+  inventoryTab: PropTypes.string.isRequired,
+  setInventoryTab: PropTypes.func.isRequired,
+  filterInventoryByType: PropTypes.func.isRequired,
+  getRarityColor: PropTypes.func.isRequired,
+};
+
+export default InventoryPanel;

--- a/src/features/Workshop.jsx
+++ b/src/features/Workshop.jsx
@@ -1,0 +1,101 @@
+import React, { useMemo } from 'react';
+import PropTypes from 'prop-types';
+import TabButton from '../components/TabButton';
+import { MATERIALS, RECIPES, ITEM_TYPES } from '../constants';
+
+const Workshop = ({
+  gameState,
+  craftingTab,
+  setCraftingTab,
+  canCraft,
+  craftItem,
+  filterRecipesByType,
+  sortRecipesByRarityAndCraftability,
+  getRarityColor,
+}) => {
+  const sortedRecipes = useMemo(
+    () => sortRecipesByRarityAndCraftability(filterRecipesByType(craftingTab)),
+    [craftingTab, gameState.materials, filterRecipesByType, sortRecipesByRarityAndCraftability]
+  );
+
+  return (
+    <div>
+      <div className="flex gap-1 mb-3 overflow-x-auto pb-1">
+        {ITEM_TYPES.map(type => {
+          const allRecipes = filterRecipesByType(type);
+          const craftableCount = allRecipes.filter(canCraft).length;
+          const totalCount = allRecipes.length;
+          return (
+            <TabButton
+              key={type}
+              active={craftingTab === type}
+              onClick={() => setCraftingTab(type)}
+              count={`${craftableCount}/${totalCount}`}
+            >
+              {type.charAt(0).toUpperCase() + type.slice(1)}
+            </TabButton>
+          );
+        })}
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-2 mb-4 max-h-80 overflow-y-auto">
+        {sortedRecipes.map(recipe => (
+          <div
+            key={recipe.id}
+            className={`border rounded-lg p-2 ${
+              canCraft(recipe)
+                ? 'border-green-300 bg-green-50 dark:bg-green-900'
+                : 'border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-700 opacity-75'
+            }`}
+          >
+            <div className="flex justify-between items-start mb-1">
+              <div className="flex-1">
+                <h4 className={`font-bold text-sm sm:text-xs ${canCraft(recipe) ? 'text-black dark:text-white' : 'text-gray-500 dark:text-gray-400'}`}>{recipe.name}</h4>
+                <p className={`text-sm px-1 py-0.5 rounded inline-block mb-1 border ${getRarityColor(recipe.rarity)}`}>
+                  {recipe.rarity}
+                </p>
+              </div>
+              <button
+                onClick={() => craftItem(recipe.id)}
+                disabled={!canCraft(recipe)}
+                className={`px-2 py-1 rounded font-bold min-h-[44px] min-w-[44px] text-sm sm:text-xs ${
+                  canCraft(recipe)
+                    ? 'bg-blue-500 hover:bg-blue-600 text-white'
+                    : 'bg-gray-200 text-gray-500 dark:bg-gray-700 dark:text-gray-400 cursor-not-allowed'
+                }`}
+              >
+                {canCraft(recipe) ? '✓ Craft' : '✗ Need Materials'}
+              </button>
+            </div>
+            <div className="flex flex-wrap gap-3 text-sm sm:text-xs text-gray-600 dark:text-gray-300">
+              {Object.entries(recipe.ingredients).map(([mat, count]) => {
+                const have = gameState.materials[mat] || 0;
+                const hasEnough = have >= count;
+                return (
+                  <span key={mat} className={`${hasEnough ? 'text-green-600' : 'text-red-600'}`}>
+                    {MATERIALS[mat].icon} {count}/{have}
+                  </span>
+                );
+              })}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+Workshop.propTypes = {
+  gameState: PropTypes.shape({
+    materials: PropTypes.object.isRequired,
+  }).isRequired,
+  craftingTab: PropTypes.string.isRequired,
+  setCraftingTab: PropTypes.func.isRequired,
+  canCraft: PropTypes.func.isRequired,
+  craftItem: PropTypes.func.isRequired,
+  filterRecipesByType: PropTypes.func.isRequired,
+  sortRecipesByRarityAndCraftability: PropTypes.func.isRequired,
+  getRarityColor: PropTypes.func.isRequired,
+};
+
+export default Workshop;


### PR DESCRIPTION
## Summary
- add generic `Card` components with headers and content
- split crafting screen into `Workshop` and `InventoryPanel`
- render market news, supply boxes, workshop, and more as collapsible cards

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6893f18e2220832085eb776dfe90b101