### PR TITLE
feat: add smart card intelligence framework

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useRef, useCallback, useMemo } from 'react'
 import { Coins, AlertCircle, Sun, Moon, Menu, BookOpen, Settings, HelpCircle } from 'lucide-react';
 import { PHASES, MATERIALS, BOX_TYPES, RECIPES } from './constants';
 import { Card, CardHeader, CardContent } from './components/Card';
+import { getDefaultCardStatesForPhase } from './utils/cardContext';
 import Workshop from './features/Workshop';
 import InventoryPanel from './features/InventoryPanel';
 import EventLog from './components/EventLog';
@@ -36,6 +37,11 @@ const MerchantsMorning = () => {
   const [menuOpen, setMenuOpen] = useState(false);
   const notificationTimers = useRef([]);
 
+  // Intelligent card handling
+  const [cardStates, setCardStates] = useState({});
+  const [cardPreferences, setCardPreferences] = useState({});
+  const [animatingCards, setAnimatingCards] = useState(new Set());
+
   const getInitialCardState = (key) => {
     if (typeof window === 'undefined') return false;
     try {
@@ -53,6 +59,18 @@ const MerchantsMorning = () => {
   const [workshopExpanded, setWorkshopExpanded] = useState(() => getInitialCardState('workshop'));
   const [inventoryExpanded, setInventoryExpanded] = useState(() => getInitialCardState('inventory'));
   const [customersExpanded, setCustomersExpanded] = useState(() => getInitialCardState('customers'));
+
+  const updateCardStatesForPhase = useCallback(
+    (phase) => {
+      const newStates = getDefaultCardStatesForPhase(phase, gameState, cardPreferences);
+      setCardStates(prev => ({ ...prev, ...newStates }));
+    },
+    [gameState, cardPreferences]
+  );
+
+  useEffect(() => {
+    updateCardStatesForPhase(gameState.phase);
+  }, [gameState.phase, updateCardStatesForPhase]);
 
   useEffect(() => {
     if (selectedCustomer) {

--- a/src/components/SmartCard.jsx
+++ b/src/components/SmartCard.jsx
@@ -1,0 +1,72 @@
+import React, { useEffect, useState } from 'react';
+import PropTypes from 'prop-types';
+import { Card, CardHeader, CardContent } from './Card';
+
+// Intelligent card wrapper with animations and context awareness
+const SmartCard = ({
+  id,
+  title,
+  icon,
+  children,
+  expanded,
+  onToggle,
+  gameState,
+  autoExpand = false,
+  priority = 0,
+}) => {
+  const [contentVisible, setContentVisible] = useState(expanded);
+  const [animating, setAnimating] = useState(false);
+
+  useEffect(() => {
+    if (autoExpand && !expanded) {
+      onToggle(true);
+    }
+  }, [autoExpand, expanded, onToggle]);
+
+  useEffect(() => {
+    if (expanded) {
+      setAnimating(true);
+      const timer = setTimeout(() => {
+        setContentVisible(true);
+        setAnimating(false);
+      }, 150);
+      return () => clearTimeout(timer);
+    } else {
+      setContentVisible(false);
+    }
+  }, [expanded]);
+
+  const handleToggle = () => {
+    onToggle(!expanded);
+  };
+
+  return (
+    <div
+      id={`card-${id}`}
+      className={`card ${animating ? (expanded ? 'expanding' : 'collapsing') : ''}`}
+      data-priority={priority}
+    >
+      <Card>
+        <CardHeader icon={icon} title={title} expanded={expanded} onToggle={handleToggle} />
+        {expanded && (
+          <CardContent className={`card-content ${contentVisible ? 'visible' : ''}`}>{children}</CardContent>
+        )}
+      </Card>
+    </div>
+  );
+};
+
+SmartCard.propTypes = {
+  id: PropTypes.string.isRequired,
+  title: PropTypes.string.isRequired,
+  icon: PropTypes.node,
+  children: PropTypes.node,
+  expanded: PropTypes.bool,
+  onToggle: PropTypes.func.isRequired,
+  gameState: PropTypes.object,
+  autoExpand: PropTypes.bool,
+  priority: PropTypes.number,
+};
+
+export default SmartCard;
+

--- a/src/hooks/useCardIntelligence.js
+++ b/src/hooks/useCardIntelligence.js
@@ -1,0 +1,128 @@
+import { useCallback, useState } from 'react';
+import { getDefaultCardStatesForPhase, getCardRelevanceScore } from '../utils/cardContext';
+import { BOX_TYPES } from '../constants';
+
+// Hook to manage smart card behaviour
+const useCardIntelligence = (gameState, userPreferences = {}) => {
+  const [cardStates, setCardStates] = useState(() =>
+    getDefaultCardStatesForPhase(gameState.phase, gameState, userPreferences)
+  );
+  const [usage, setUsage] = useState({});
+
+  const getCardState = useCallback(
+    (id) => cardStates[id] || { expanded: false, hidden: false },
+    [cardStates]
+  );
+
+  const updateCardState = useCallback((id, updates) => {
+    setCardStates((prev) => ({
+      ...prev,
+      [id]: { ...getCardState(id), ...updates },
+    }));
+  }, [getCardState]);
+
+  const getCardPriority = useCallback(
+    (cardType, gs = gameState, userActivity = {}) =>
+      getCardRelevanceScore(cardType, { ...gs, ...userActivity }),
+    [gameState]
+  );
+
+  const addToPreferredExpansions = useCallback((phase, cardId) => {
+    if (!userPreferences.preferredExpansions) {
+      userPreferences.preferredExpansions = {};
+    }
+    const list = new Set(userPreferences.preferredExpansions[phase] || []);
+    list.add(cardId);
+    userPreferences.preferredExpansions[phase] = Array.from(list);
+  }, [userPreferences]);
+
+  const getStoredUsage = () => {
+    if (typeof window === 'undefined') return {};
+    try {
+      return JSON.parse(window.localStorage.getItem('cardUsage') || '{}');
+    } catch {
+      return {};
+    }
+  };
+
+  const storeUsage = (data) => {
+    if (typeof window === 'undefined') return;
+    try {
+      window.localStorage.setItem('cardUsage', JSON.stringify(data));
+    } catch {
+      /* noop */
+    }
+  };
+
+  const trackCardUsage = useCallback((cardId, action) => {
+    setUsage((prev) => {
+      const usageData = { ...prev };
+      const cardUsage = usageData[cardId] || { expansions: 0, lastUsed: null };
+      if (action === 'expand') {
+        cardUsage.expansions += 1;
+        cardUsage.lastUsed = Date.now();
+        if (cardUsage.expansions > 5) {
+          addToPreferredExpansions(gameState.phase, cardId);
+        }
+      }
+      usageData[cardId] = cardUsage;
+      storeUsage(usageData);
+      return usageData;
+    });
+  }, [addToPreferredExpansions, gameState.phase]);
+
+  const getCardStatus = useCallback((cardType, gs = gameState) => {
+    switch (cardType) {
+      case 'supplyBoxes': {
+        const affordable = Object.entries(BOX_TYPES).filter(([, box]) => (gs.gold || 0) >= box.cost);
+        return {
+          subtitle: affordable.length > 0
+            ? `${affordable[0][1].name} available`
+            : `Need ${BOX_TYPES.bronze.cost - (gs.gold || 0)}g more`,
+          status: affordable.length > 0 ? 'available' : 'locked',
+          badge: affordable.length,
+        };
+      }
+      case 'materials': {
+        const total = Object.values(gs.materials || {}).reduce((s, c) => s + c, 0);
+        const newMaterials = gs.newMaterialsCount || 0;
+        return {
+          subtitle: `${total} items${newMaterials > 0 ? ` • ${newMaterials} new` : ''}`,
+          status: newMaterials > 0 ? 'updated' : 'normal',
+          badge: total,
+        };
+      }
+      case 'workshop': {
+        const craftable = gs.craftableCount || 0;
+        const totalRecipes = gs.totalRecipeCount || 0;
+        return {
+          subtitle: `${craftable}/${totalRecipes} craftable`,
+          status: craftable > 0 ? 'ready' : 'waiting',
+          badge: craftable,
+        };
+      }
+      case 'customerQueue': {
+        const waiting = (gs.customers || []).filter(c => !c.satisfied);
+        const vip = waiting.filter(c => c.budgetTier === 'wealthy');
+        return {
+          subtitle: `${waiting.length} waiting${vip.length > 0 ? ` • ${vip.length} VIP` : ''}`,
+          status: vip.length > 0 ? 'vip' : 'normal',
+          badge: waiting.length,
+        };
+      }
+      default:
+        return { subtitle: '', status: 'normal', badge: 0 };
+    }
+  }, [gameState]);
+
+  return {
+    getCardState,
+    updateCardState,
+    getCardPriority,
+    trackCardUsage,
+    getCardStatus,
+  };
+};
+
+export default useCardIntelligence;
+

--- a/src/index.css
+++ b/src/index.css
@@ -186,3 +186,78 @@ textarea:focus {
   0% { transform: rotate(0deg); }
   100% { transform: rotate(360deg); }
 }
+
+/* Smart card animations */
+.card {
+  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  transform-origin: top center;
+}
+
+.card.expanding {
+  animation: cardExpand 0.3s ease-out;
+}
+
+.card.collapsing {
+  animation: cardCollapse 0.25s ease-in;
+}
+
+@keyframes cardExpand {
+  0% {
+    transform: scaleY(0.3);
+    opacity: 0.7;
+  }
+  100% {
+    transform: scaleY(1);
+    opacity: 1;
+  }
+}
+
+@keyframes cardCollapse {
+  0% {
+    transform: scaleY(1);
+    opacity: 1;
+  }
+  100% {
+    transform: scaleY(0.3);
+    opacity: 0.7;
+  }
+}
+
+/* Card header status indicators */
+.card-header.status-available {
+  border-left: 4px solid #10b981;
+}
+
+.card-header.status-locked {
+  border-left: 4px solid #ef4444;
+  opacity: 0.7;
+}
+
+.card-header.status-updated {
+  border-left: 4px solid #3b82f6;
+  animation: newContentPulse 2s ease-in-out;
+}
+
+.card-header.status-vip {
+  border-left: 4px solid #f59e0b;
+  background: linear-gradient(90deg, transparent, rgba(251, 191, 36, 0.1), transparent);
+}
+
+@keyframes newContentPulse {
+  0%, 100% { border-left-color: #3b82f6; }
+  50% { border-left-color: #60a5fa; }
+}
+
+/* Content fade-in */
+.card-content {
+  opacity: 0;
+  transition: opacity 0.15s ease-in;
+}
+.card-content.visible {
+  opacity: 1;
+}
+
+/* Success glow animation */
+.success-glow {
+  box-shadow: 0 0 0 4px rgba(16, 185, 129, 0.5);
+}

--- a/src/utils/cardContext.js
+++ b/src/utils/cardContext.js
@@ -1,0 +1,122 @@
+import { PHASES, BOX_TYPES } from '../constants';
+
+// Determine default card states based on game phase and user prefs
+export const getDefaultCardStatesForPhase = (phase, gameState = {}, userPrefs = {}) => {
+  const states = {
+    supplyBoxes: { expanded: false, hidden: false },
+    marketNews: { expanded: false, hidden: false },
+    materials: { expanded: false, hidden: false },
+    workshop: { expanded: false, hidden: false },
+    inventory: { expanded: false, hidden: false },
+    customerQueue: { expanded: false, hidden: false },
+    endOfDay: { expanded: false, hidden: false },
+  };
+
+  switch (phase) {
+    case PHASES.MORNING:
+      states.supplyBoxes.expanded = true;
+      states.marketNews.expanded = (gameState.marketReports || []).length > 0;
+      states.materials.expanded = false;
+      states.workshop.expanded = false;
+      states.inventory.expanded = false;
+      states.customerQueue.hidden = true;
+      break;
+    case PHASES.CRAFTING:
+      states.supplyBoxes.expanded = false;
+      states.marketNews.expanded = false;
+      states.materials.expanded = true;
+      states.workshop.expanded = true;
+      states.inventory.expanded = false;
+      states.customerQueue.hidden = true;
+      break;
+    case PHASES.SHOPPING:
+      states.supplyBoxes.hidden = true;
+      states.marketNews.hidden = true;
+      states.materials.expanded = false;
+      states.workshop.hidden = true;
+      states.inventory.expanded = true;
+      states.customerQueue.expanded = true;
+      break;
+    case PHASES.END_DAY:
+      Object.keys(states).forEach(k => { states[k].expanded = false; });
+      break;
+    default:
+      break;
+  }
+
+  const exp = userPrefs?.preferredExpansions?.[phase] || [];
+  exp.forEach(card => {
+    if (states[card]) {
+      states[card].expanded = true;
+      states[card].hidden = false;
+    }
+  });
+
+  const col = userPrefs?.preferredCollapsed?.[phase] || [];
+  col.forEach(card => {
+    if (states[card]) {
+      states[card].expanded = false;
+    }
+  });
+
+  return states;
+};
+
+// Determine if a card should auto-expand based on context
+export const shouldAutoExpand = (cardType, gameState = {}, userActivity = {}) => {
+  if (cardType === 'marketNews') {
+    return (gameState.marketReports || []).length > 0;
+  }
+  if (cardType === 'materials') {
+    return !!userActivity.newMaterialsReceived;
+  }
+  if (cardType === 'supplyBoxes') {
+    const goldCost = BOX_TYPES?.gold?.cost || Infinity;
+    return gameState.gold >= goldCost && !userActivity.hasSeenGoldBox;
+  }
+  if (cardType === 'workshop') {
+    const current = userActivity.craftableRecipeCount || 0;
+    const prev = userActivity.previousCraftableCount || 0;
+    return current > prev;
+  }
+  return false;
+};
+
+// Calculate a relevance score used for ordering
+export const getCardRelevanceScore = (cardType, gameState = {}) => {
+  const basePriority = {
+    marketNews: 1,
+    supplyBoxes: 2,
+    materials: 3,
+    workshop: 4,
+    inventory: 5,
+    customerQueue: 6,
+  };
+
+  let priority = basePriority[cardType] ?? 99;
+
+  if (cardType === 'supplyBoxes' && gameState.gold >= (BOX_TYPES.platinum?.cost || Infinity)) {
+    priority -= 2;
+  }
+
+  if (cardType === 'workshop' && (gameState.craftableCount || 0) > 5) {
+    priority -= 1;
+  }
+
+  if (cardType === 'customerQueue' && gameState.hasVIPCustomers) {
+    priority -= 3;
+  }
+
+  if (typeof gameState.isCardEmpty === 'function' && gameState.isCardEmpty(cardType)) {
+    priority += 10;
+  }
+
+  return priority;
+};
+
+export default {
+  getDefaultCardStatesForPhase,
+  shouldAutoExpand,
+  getCardRelevanceScore,
+};
+


### PR DESCRIPTION
## Summary
- scaffold smart card intelligence with phase-aware state tracking and user preferences
- introduce SmartCard component with auto-expansion hooks and animation-ready markup
- add CSS transitions and status indicator styles for card animations

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_6894bded9d2c8320a9e5fcf7eb962ce1