### PR TITLE
refactor: use useCardIntelligence for card state

### DIFF
--- a/src/hooks/useCardIntelligence.js
+++ b/src/hooks/useCardIntelligence.js
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useState, useEffect } from 'react';
 import { getDefaultCardStatesForPhase, getCardRelevanceScore } from '../utils/cardContext';
 import { BOX_TYPES } from '../constants';
 
@@ -8,6 +8,13 @@ const useCardIntelligence = (gameState, userPreferences = {}) => {
     getDefaultCardStatesForPhase(gameState.phase, gameState, userPreferences)
   );
   const [usage, setUsage] = useState({});
+
+  useEffect(() => {
+    setCardStates((prev) => ({
+      ...prev,
+      ...getDefaultCardStatesForPhase(gameState.phase, gameState, userPreferences),
+    }));
+  }, [gameState.phase, gameState, userPreferences]);
 
   const getCardState = useCallback(
     (id) => cardStates[id] || { expanded: false, hidden: false },
@@ -73,6 +80,16 @@ const useCardIntelligence = (gameState, userPreferences = {}) => {
 
   const getCardStatus = useCallback((cardType, gs = gameState) => {
     switch (cardType) {
+      case 'marketNews': {
+        const reports = gs.marketReports || [];
+        return {
+          subtitle: reports.length > 0
+            ? `${reports.length} report${reports.length !== 1 ? 's' : ''}`
+            : 'No reports today',
+          status: reports.length > 0 ? 'normal' : 'locked',
+          badge: reports.length,
+        };
+      }
       case 'supplyBoxes': {
         const affordable = Object.entries(BOX_TYPES).filter(([, box]) => (gs.gold || 0) >= box.cost);
         return {
@@ -99,6 +116,14 @@ const useCardIntelligence = (gameState, userPreferences = {}) => {
           subtitle: `${craftable}/${totalRecipes} craftable`,
           status: craftable > 0 ? 'ready' : 'waiting',
           badge: craftable,
+        };
+      }
+      case 'inventory': {
+        const total = Object.values(gs.inventory || {}).reduce((s, c) => s + c, 0);
+        return {
+          subtitle: `${total} items`,
+          status: 'normal',
+          badge: total,
         };
       }
       case 'customerQueue': {


### PR DESCRIPTION
## Summary
- replace manual card state tracking with `useCardIntelligence`
- update card components to leverage smart card state and status
- expand `useCardIntelligence` with market news and inventory support

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_6894c49390e48320a3b36d11edcaaa9b