### PR TITLE
Fix eslint warnings in hooks and utilities

### DIFF
--- a/src/hooks/useGestures.js
+++ b/src/hooks/useGestures.js
@@ -1,7 +1,7 @@
 import { useEffect } from 'react';
 
 const useGestures = (ref, options = {}) => {
-  const { onSwipe, onLongPress, onPinch, onMultiTouch } = options;
+  const { onSwipe, onLongPress, onMultiTouch } = options;
 
   useEffect(() => {
     const el = ref && 'current' in ref ? ref.current : ref;
@@ -76,12 +76,6 @@ const useGestures = (ref, options = {}) => {
       }
     };
 
-    const handleTouchStartPassive = (e) => {
-      if (e.touches.length > 1) {
-        e.preventDefault();
-      }
-    };
-
     el.addEventListener('touchstart', handleTouchStart, { passive: false });
     el.addEventListener('touchmove', handleTouchMove, { passive: true });
     el.addEventListener('touchend', handleTouchEnd, { passive: true });
@@ -91,7 +85,15 @@ const useGestures = (ref, options = {}) => {
       el.removeEventListener('touchmove', handleTouchMove);
       el.removeEventListener('touchend', handleTouchEnd);
     };
-  }, [ref, onSwipe, onLongPress, onPinch, onMultiTouch, options.longPressDelay, options.swipeThreshold, options.swipeTimeLimit]);
+  }, [
+    ref,
+    onSwipe,
+    onLongPress,
+    onMultiTouch,
+    options.longPressDelay,
+    options.swipeThreshold,
+    options.swipeTimeLimit,
+  ]);
 };
 
 export default useGestures;

--- a/src/utils/cardContext.js
+++ b/src/utils/cardContext.js
@@ -59,6 +59,8 @@ export const getDefaultCardStatesForPhase = (phase, gameState = {}, userPrefs = 
       });
       break;
     }
+    default:
+      break;
   }
 
   // Apply user preferences (these override smart defaults)
@@ -105,6 +107,8 @@ export const getCardRelevanceScore = (cardType, gameState = {}) => {
     case PHASES.SHOPPING:
       if (cardType === 'customerQueue') priority -= 2;
       if (cardType === 'inventory') priority -= 1;
+      break;
+    default:
       break;
   }
 


### PR DESCRIPTION
## Summary
- ensure card intelligence hook defines helpers before use and includes complete effect dependencies
- drop unused gesture handler and pinch support
- add default cases in card context switch statements

## Testing
- `npx eslint .`
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_6895607bcca48320a0830de987a353de