### PR TITLE
Fix customer queue visibility in shopping phase

### DIFF
--- a/src/utils/__tests__/cardContext.test.js
+++ b/src/utils/__tests__/cardContext.test.js
@@ -1,0 +1,10 @@
+import { getDefaultCardStatesForPhase } from '../cardContext';
+import { PHASES } from '../../constants';
+
+describe('card context defaults', () => {
+  test('customer queue is visible in shopping phase', () => {
+    const states = getDefaultCardStatesForPhase(PHASES.SHOPPING);
+    expect(states.customerQueue.hidden).toBe(false);
+    expect(states.customerQueue.expanded).toBe(true);
+  });
+});

--- a/src/utils/cardContext.js
+++ b/src/utils/cardContext.js
@@ -42,6 +42,7 @@ export const getDefaultCardStatesForPhase = (phase, gameState = {}, userPrefs = 
       states.marketNews.hidden = true;
       states.workshop.hidden = true;
       states.inventory.expanded = true;
+      states.customerQueue.hidden = false;
       states.customerQueue.expanded = true;
 
       // Smart logic: If materials are low, collapse materials card


### PR DESCRIPTION
## Summary
- Ensure customer queue is unhidden during the shopping phase
- Add test covering default card state for customer queue visibility

## Testing
- `CI=true npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_6895f2ef50f48320a013259ae4222104