### PR TITLE
fix: use safe ID generator for customer queue

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -14,6 +14,7 @@ import useGameState from './hooks/useGameState';
 import ShopInterface from './features/ShopInterface';
 import EndOfDaySummary from './features/EndOfDaySummary';
 import useCardIntelligence from './hooks/useCardIntelligence';
+import generateId from './utils/id';
 
 const MerchantsMorning = () => {
   const [gameState, setGameState, resetGame] = useGameState();
@@ -138,7 +139,7 @@ const MerchantsMorning = () => {
 
   const addEvent = (message, type = 'info') => {
     const event = {
-      id: crypto.randomUUID(),
+      id: generateId(),
       message,
       type,
       timestamp: new Date().toLocaleTimeString()
@@ -148,7 +149,7 @@ const MerchantsMorning = () => {
 
   const addNotification = (message, type = 'success') => {
     const notification = {
-      id: crypto.randomUUID(),
+      id: generateId(),
       message,
       type
     };

--- a/src/hooks/useCustomers.js
+++ b/src/hooks/useCustomers.js
@@ -3,6 +3,7 @@ import { random } from '../utils/random';
 import { getRarityRank } from '../utils/rarity';
 import { generateMarketReports } from '../utils/marketReports';
 import { getMaterialValue } from '../utils/materialValue';
+import generateId from '../utils/id';
 
 const useCustomers = (gameState, setGameState, addEvent, addNotification, setSelectedCustomer) => {
   const generateCustomers = () => {
@@ -96,7 +97,7 @@ const useCustomers = (gameState, setGameState, addEvent, addNotification, setSel
       }
 
       customers.push({
-        id: crypto.randomUUID(),
+        id: generateId(),
         name: generateProfessionName(professionKey),
         profession: professionKey,
         requestType,

--- a/src/utils/id.js
+++ b/src/utils/id.js
@@ -1,0 +1,7 @@
+export const generateId = () => (
+  typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'
+    ? crypto.randomUUID()
+    : Math.random().toString(36).slice(2)
+);
+
+export default generateId;


### PR DESCRIPTION
## Summary
- add utility to generate IDs without relying on `crypto.randomUUID`
- use new generator for events, notifications, and customer creation

## Testing
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_689611ef38c08320bdc3cdf56a1e8735