### PR TITLE
Switch to emoji-based controls

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -589,32 +589,36 @@ const MerchantsMorning = () => {
                           addNotification('⚒️ Crafting phase started', 'info');
                         }}
                         className="w-full h-12 rounded-lg font-bold text-white bg-green-500 hover:bg-green-600 shadow"
+                        aria-label="Start Crafting"
                       >
-                        START CRAFTING
+                        ⚒️
                       </Button>
                     )}
                     {gameState.phase === PHASES.CRAFTING && (
                       <Button
                         onClick={openShop}
                         className="w-full h-12 rounded-lg font-bold text-white bg-blue-500 hover:bg-blue-600 shadow"
+                        aria-label="Open Shop"
                       >
-                        OPEN SHOP
+                        🏪
                       </Button>
                     )}
                     {gameState.phase === PHASES.SHOPPING && (
                       <Button
                         onClick={endDay}
                         className="w-full h-12 rounded-lg font-bold text-white bg-purple-500 hover:bg-purple-600 shadow"
+                        aria-label="Close Shop"
                       >
-                        CLOSE SHOP
+                        🔒
                       </Button>
                     )}
                     {gameState.phase === PHASES.END_DAY && (
                       <Button
                         onClick={startNewDay}
                         className="w-full h-12 rounded-lg font-bold text-white bg-amber-500 hover:bg-amber-600 shadow"
+                        aria-label="New Day"
                       >
-                        NEW DAY
+                        🌅
                       </Button>
                     )}
                   </div>

--- a/src/components/TabButton.jsx
+++ b/src/components/TabButton.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-const TabButton = ({ active, onClick, children, count }) => (
+const TabButton = ({ active, onClick, children, count, ...props }) => (
   <button
     onClick={onClick}
     className={`relative flex-1 flex items-center justify-center px-4 py-3 rounded-lg min-h-[48px] text-sm font-medium text-center whitespace-nowrap ${
@@ -9,6 +9,7 @@ const TabButton = ({ active, onClick, children, count }) => (
         ? 'bg-blue-500 text-white'
         : 'bg-gray-100 text-gray-600 hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600'
     }`}
+    {...props}
   >
     {children}
     {count !== undefined && count !== null && (

--- a/src/components/__tests__/TabButton.test.jsx
+++ b/src/components/__tests__/TabButton.test.jsx
@@ -5,23 +5,23 @@ import TabButton from '../TabButton.jsx';
 describe('TabButton', () => {
   test('shows count even when zero', () => {
     render(
-      <TabButton active={false} onClick={() => {}} count={0}>
-        Weapons
+      <TabButton active={false} onClick={() => {}} count={0} aria-label="Weapons">
+        ⚔️
       </TabButton>
     );
-    const button = screen.getByRole('button');
-    expect(button).toHaveTextContent('Weapons');
+    const button = screen.getByRole('button', { name: 'Weapons' });
+    expect(button).toHaveTextContent('⚔️');
     expect(button).toHaveTextContent('0');
   });
 
   test('hides count when not provided', () => {
     render(
-      <TabButton active={false} onClick={() => {}}>
-        Armor
+      <TabButton active={false} onClick={() => {}} aria-label="Armor">
+        🛡️
       </TabButton>
     );
-    const button = screen.getByRole('button');
-    expect(button).toHaveTextContent('Armor');
-    expect(button).not.toHaveTextContent(/\(/);
+    const button = screen.getByRole('button', { name: 'Armor' });
+    expect(button).toHaveTextContent('🛡️');
+    expect(button).not.toHaveTextContent('0');
   });
 });

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -2,5 +2,5 @@ export { PHASES } from './phases';
 export { MATERIALS, MATERIAL_VALUE_RANGE } from './materials';
 export { RECIPES } from './recipes';
 export { BOX_TYPES } from './boxes';
-export { ITEM_TYPES, RARITY_ORDER, BUDGET_TIERS } from './items';
+export { ITEM_TYPES, RARITY_ORDER, BUDGET_TIERS, ITEM_TYPE_ICONS } from './items';
 export { PROFESSIONS, generateProfessionName } from './professions';

--- a/src/constants/items.js
+++ b/src/constants/items.js
@@ -1,3 +1,11 @@
 export const ITEM_TYPES = ['weapon', 'armor', 'trinket', 'potion', 'tool'];
 export const RARITY_ORDER = { legendary: 4, rare: 3, uncommon: 2, common: 1 };
 export const BUDGET_TIERS = ['budget', 'middle', 'wealthy'];
+
+export const ITEM_TYPE_ICONS = {
+  weapon: '⚔️',
+  armor: '🛡️',
+  trinket: '💍',
+  potion: '🧪',
+  tool: '🛠️',
+};

--- a/src/features/CraftingPanel.jsx
+++ b/src/features/CraftingPanel.jsx
@@ -1,7 +1,7 @@
 import React, { useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { Hammer } from 'lucide-react';
-import { MATERIALS, RECIPES, ITEM_TYPES } from '../constants';
+import { MATERIALS, RECIPES, ITEM_TYPES, ITEM_TYPE_ICONS } from '../constants';
 import TabButton from '../components/TabButton';
 import { compareRarities } from '../utils/rarity';
 
@@ -54,8 +54,9 @@ const CraftingPanel = ({
               active={craftingTab === type}
               onClick={() => setCraftingTab(type)}
               count={`${craftableCount}/${totalCount}`}
+              aria-label={type.charAt(0).toUpperCase() + type.slice(1)}
             >
-              {type.charAt(0).toUpperCase() + type.slice(1)}
+              {ITEM_TYPE_ICONS[type]}
             </TabButton>
           );
         })}
@@ -118,8 +119,9 @@ const CraftingPanel = ({
               active={inventoryTab === type}
               onClick={() => setInventoryTab(type)}
               count={count}
+              aria-label={type.charAt(0).toUpperCase() + type.slice(1)}
             >
-              {type.charAt(0).toUpperCase() + type.slice(1)}
+              {ITEM_TYPE_ICONS[type]}
             </TabButton>
           );
         })}

--- a/src/features/InventoryPanel.jsx
+++ b/src/features/InventoryPanel.jsx
@@ -1,7 +1,7 @@
 import React, { useMemo } from 'react';
 import PropTypes from 'prop-types';
 import TabButton from '../components/TabButton';
-import { RECIPES, ITEM_TYPES } from '../constants';
+import { RECIPES, ITEM_TYPES, ITEM_TYPE_ICONS } from '../constants';
 
 const InventoryPanel = ({
   gameState,
@@ -33,8 +33,9 @@ const InventoryPanel = ({
               active={inventoryTab === type}
               onClick={() => setInventoryTab(type)}
               count={count}
+              aria-label={type.charAt(0).toUpperCase() + type.slice(1)}
             >
-              {type.charAt(0).toUpperCase() + type.slice(1)}
+              {ITEM_TYPE_ICONS[type]}
             </TabButton>
           );
         })}

--- a/src/features/ShopInterface.jsx
+++ b/src/features/ShopInterface.jsx
@@ -2,7 +2,7 @@ import React, { useMemo, useState } from 'react';
 import PropTypes from 'prop-types';
 import { Store } from 'lucide-react';
 import TabButton from '../components/TabButton';
-import { ITEM_TYPES, RECIPES, PROFESSIONS, MATERIALS } from '../constants';
+import { ITEM_TYPES, RECIPES, PROFESSIONS, MATERIALS, ITEM_TYPE_ICONS } from '../constants';
 
 const ShopInterface = ({
   gameState,
@@ -127,8 +127,9 @@ const ShopInterface = ({
               active={sellingTab === type}
               onClick={() => setSellingTab(type)}
               count={count}
+              aria-label={type.charAt(0).toUpperCase() + type.slice(1)}
             >
-              {type.charAt(0).toUpperCase() + type.slice(1)}
+              {ITEM_TYPE_ICONS[type]}
             </TabButton>
           );
         })}

--- a/src/features/Workshop.jsx
+++ b/src/features/Workshop.jsx
@@ -1,7 +1,7 @@
 import React, { useMemo } from 'react';
 import PropTypes from 'prop-types';
 import TabButton from '../components/TabButton';
-import { MATERIALS, RECIPES, ITEM_TYPES } from '../constants';
+import { MATERIALS, RECIPES, ITEM_TYPES, ITEM_TYPE_ICONS } from '../constants';
 
 const Workshop = ({
   gameState,
@@ -31,8 +31,9 @@ const Workshop = ({
               active={craftingTab === type}
               onClick={() => setCraftingTab(type)}
               count={`${craftableCount}/${totalCount}`}
+              aria-label={type.charAt(0).toUpperCase() + type.slice(1)}
             >
-              {type.charAt(0).toUpperCase() + type.slice(1)}
+              {ITEM_TYPE_ICONS[type]}
             </TabButton>
           );
         })}


### PR DESCRIPTION
## Summary
- add ITEM_TYPE_ICONS constant and export
- render item type tabs with emojis and aria-labels
- replace phase control buttons with emoji icons

## Testing
- `npm test --silent -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_6896158f2ee08320bad2ef233248b3ab