### PR TITLE
feat: add visual indicators and customer avatars

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -19,6 +19,14 @@ import generateId from './utils/id';
 const MerchantsMorning = () => {
   const [gameState, setGameState, resetGame] = useGameState();
 
+  const PHASE_SEQUENCE = [PHASES.MORNING, PHASES.CRAFTING, PHASES.SHOPPING, PHASES.END_DAY];
+  const PHASE_ICONS = {
+    [PHASES.MORNING]: '🌅',
+    [PHASES.CRAFTING]: '🔨',
+    [PHASES.SHOPPING]: '🏪',
+    [PHASES.END_DAY]: '🌙',
+  };
+
   // Stable user preferences loader
   const [prefsVersion, setPrefsVersion] = useState(0);
 
@@ -284,7 +292,19 @@ const MerchantsMorning = () => {
           <div className="flex items-start justify-between">
             <div>
               <h1 className="text-lg sm:text-xl font-bold text-amber-800 dark:text-amber-300">🏰 Merchant's Morning</h1>
-              <p className="text-sm sm:text-xs text-amber-600 dark:text-amber-400">Day {gameState.day} • {gameState.phase.replace('_', ' ').toUpperCase()}</p>
+              <p className="text-sm sm:text-xs text-amber-600 dark:text-amber-400 flex items-center gap-2">
+                <span>Day {gameState.day}</span>
+                <span className="flex items-center gap-1">
+                  {PHASE_SEQUENCE.map(phase => (
+                    <span
+                      key={phase}
+                      className={phase === gameState.phase ? 'text-base' : 'opacity-40'}
+                    >
+                      {PHASE_ICONS[phase]}
+                    </span>
+                  ))}
+                </span>
+              </p>
             </div>
             <div className="relative">
               <button
@@ -447,11 +467,23 @@ const MerchantsMorning = () => {
                         Object.entries(materialsByType).map(([type, mats]) => (
                           <div key={type} className="mb-2">
                             <h4 className="font-semibold text-sm mb-1 capitalize">{type}</h4>
-                            <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+                            <div className="grid grid-cols-2 sm:grid-cols-4 gap-2">
                               {mats.map(({ id, count, material }) => (
-                                <div key={id} className={`p-2 rounded text-sm sm:text-xs ${getRarityColor(material.rarity)}`}>
-                                  <span className="mr-1">{material.icon}</span>
-                                  {material.name}: {count}
+                                <div
+                                  key={id}
+                                  className={`relative flex flex-col items-center justify-end h-16 border rounded ${getRarityColor(material.rarity)}`}
+                                >
+                                  <div className="flex flex-col-reverse items-center">
+                                    {Array.from({ length: Math.min(count, 5) }).map((_, i) => (
+                                      <span key={i} className="leading-none text-lg">
+                                        {material.icon}
+                                      </span>
+                                    ))}
+                                  </div>
+                                  {count > 5 && (
+                                    <span className="absolute top-1 right-1 text-xs">+{count - 5}</span>
+                                  )}
+                                  <span className="sr-only">{material.name}: {count}</span>
                                 </div>
                               ))}
                             </div>
@@ -474,12 +506,12 @@ const MerchantsMorning = () => {
               <CardHeader
                 icon="🔨"
                 title="Workshop"
-                subtitle={workshopStatus.subtitle}
-                subtitleClassName={workshopStatus.status === 'locked' ? 'text-red-600' : ''}
                 expanded={getCardState('workshop').expanded}
                 onToggle={() => handleCardToggle('workshop')}
                 status={workshopStatus.status}
                 badge={workshopStatus.badge}
+                progress={{ current: craftableRecipes, total: totalRecipes }}
+                subtitle={workshopStatus.subtitle}
               />
               {getCardState('workshop').expanded && (
                 <CardContent expanded={getCardState('workshop').expanded}>

--- a/src/components/Card.jsx
+++ b/src/components/Card.jsx
@@ -15,22 +15,45 @@ Card.propTypes = {
 export const CardHeader = ({ 
   icon, 
   title, 
-  subtitle, 
-  expanded, 
-  onToggle, 
-  isEmpty, 
+  subtitle,
+  expanded,
+  onToggle,
+  isEmpty,
   subtitleClassName = '',
   status = 'normal',
   badge,
-  animating = false
+  animating = false,
+  progress
 }) => {
   const getStatusClass = () => {
     switch (status) {
-      case 'available': return 'card-header status-available';
-      case 'locked': return 'card-header status-locked';
-      case 'updated': return 'card-header status-updated';
-      case 'vip': return 'card-header status-vip';
-      default: return 'card-header';
+      case 'available':
+      case 'ready':
+        return 'card-header status-available';
+      case 'locked':
+        return 'card-header status-locked';
+      case 'updated':
+        return 'card-header status-updated';
+      case 'vip':
+        return 'card-header status-vip';
+      default:
+        return 'card-header';
+    }
+  };
+
+  const statusDotColor = () => {
+    switch (status) {
+      case 'available':
+      case 'ready':
+        return 'bg-green-500';
+      case 'locked':
+        return 'bg-red-500';
+      case 'updated':
+        return 'bg-blue-500';
+      case 'vip':
+        return 'bg-purple-500';
+      default:
+        return 'bg-gray-400';
     }
   };
 
@@ -42,25 +65,30 @@ export const CardHeader = ({
       } ${animating ? 'animate-pulse' : ''}`}
       aria-expanded={expanded}
     >
-      <div className="flex items-center gap-2">
-        <span className="text-lg" aria-hidden="true">{icon}</span>
-        <span className="font-bold">{title}</span>
+      <div className="flex items-center gap-3">
+        <span className="text-2xl" aria-hidden="true">{icon}</span>
+        <span className="sr-only">{title}</span>
         {badge !== undefined && badge > 0 && (
           <span
-            className="ml-2 px-2 py-1 text-xs bg-blue-500 text-white rounded-full"
+            className="px-2 py-1 text-xs bg-blue-500 text-white rounded-full"
             aria-label={`${badge} items`}
           >
             {badge}
           </span>
         )}
-      </div>
-      <div className="flex items-center gap-2">
-        {subtitle && (
-          <span className={`text-sm ${subtitleClassName}`}>{subtitle}</span>
+        {progress && (
+          <div className="w-24 h-2 bg-gray-200 rounded-full overflow-hidden">
+            <div
+              className="h-full bg-green-500"
+              style={{ width: `${(progress.current / progress.total) * 100}%` }}
+            />
+          </div>
         )}
-        <span className={`transition-transform duration-200 ${expanded ? 'rotate-180' : ''}`}>
-          ▼
-        </span>
+      </div>
+      <div className="flex items-center gap-3">
+        {subtitle && <span className="sr-only">{subtitle}</span>}
+        <span className={`w-3 h-3 rounded-full ${statusDotColor()}`}></span>
+        <span className={`transition-transform duration-200 ${expanded ? 'rotate-180' : ''}`}>▼</span>
       </div>
     </button>
   );
@@ -74,9 +102,13 @@ CardHeader.propTypes = {
   onToggle: PropTypes.func.isRequired,
   isEmpty: PropTypes.bool,
   subtitleClassName: PropTypes.string,
-  status: PropTypes.oneOf(['normal', 'available', 'locked', 'updated', 'vip']),
+  status: PropTypes.oneOf(['normal', 'available', 'locked', 'updated', 'vip', 'ready', 'waiting']),
   badge: PropTypes.number,
   animating: PropTypes.bool,
+  progress: PropTypes.shape({
+    current: PropTypes.number.isRequired,
+    total: PropTypes.number.isRequired,
+  }),
 };
 
 export const CardContent = ({ children, expanded = true }) => (

--- a/src/features/InventoryPanel.jsx
+++ b/src/features/InventoryPanel.jsx
@@ -41,18 +41,28 @@ const InventoryPanel = ({
         })}
       </div>
 
-      <div className="space-y-2 max-h-80 overflow-y-auto">
+      <div className="grid grid-cols-3 sm:grid-cols-4 gap-2 max-h-80 overflow-y-auto">
         {sortedInventory.map(([itemId, count]) => {
           const recipe = RECIPES.find(r => r.id === itemId);
           return (
-            <div key={itemId} className={`p-2 rounded text-sm sm:text-xs border ${getRarityColor(recipe.rarity)}`}>
-              <div className="font-bold">{recipe.name}</div>
-              <div className="text-gray-600 dark:text-gray-300">Stock: {count} • {recipe.sellPrice}g each</div>
+            <div
+              key={itemId}
+              className={`relative flex flex-col items-center justify-end h-20 border rounded ${getRarityColor(recipe.rarity)}`}
+            >
+              <div className="flex flex-col-reverse items-center">
+                {Array.from({ length: Math.min(count, 5) }).map((_, i) => (
+                  <span key={i} className="text-xl leading-none">
+                    {ITEM_TYPE_ICONS[recipe.type]}
+                  </span>
+                ))}
+              </div>
+              {count > 5 && <span className="absolute top-1 right-1 text-xs">+{count - 5}</span>}
+              <span className="sr-only">{recipe.name} x{count}</span>
             </div>
           );
         })}
         {sortedInventory.length === 0 && (
-          <p className="text-sm sm:text-xs text-gray-500 italic dark:text-gray-400">No {inventoryTab}s crafted yet</p>
+          <p className="text-sm sm:text-xs text-gray-500 italic dark:text-gray-400 col-span-full">No {inventoryTab}s crafted yet</p>
         )}
       </div>
     </div>

--- a/src/features/ShopInterface.jsx
+++ b/src/features/ShopInterface.jsx
@@ -4,6 +4,18 @@ import { Store } from 'lucide-react';
 import TabButton from '../components/TabButton';
 import { ITEM_TYPES, RECIPES, PROFESSIONS, MATERIALS, ITEM_TYPE_ICONS } from '../constants';
 
+const PROFESSION_STYLES = {
+  knight: { icon: '🛡️', border: 'border-gray-400' },
+  ranger: { icon: '🏹', border: 'border-green-400' },
+  mage: { icon: '🧙', border: 'border-purple-400' },
+  merchant: { icon: '💼', border: 'border-yellow-400' },
+  noble: { icon: '👑', border: 'border-pink-400' },
+  guard: { icon: '🛡️', border: 'border-blue-400' },
+};
+
+const RARITY_GEMS = { common: '⚪', uncommon: '🟢', rare: '💎', legendary: '🟡' };
+const BUDGET_HEIGHT = { wealthy: '100%', middle: '60%', budget: '30%' };
+
 const ShopInterface = ({
   gameState,
   selectedCustomer,
@@ -58,30 +70,40 @@ const ShopInterface = ({
         </select>
       </div>
 
-      <div className="hidden sm:flex gap-2 overflow-x-auto pb-2">
-        {gameState.customers.filter(c => !c.satisfied).map(customer => (
-          <button
-            key={customer.id}
-            onClick={() => {
-              setSelectedCustomer(customer);
-              setSellingTab(customer.requestType);
-            }}
-            className={`px-4 py-2 rounded-lg whitespace-nowrap font-medium transition-colors min-h-[44px] min-w-[44px] text-sm sm:text-xs ${
-              selectedCustomer?.id === customer.id
-                ? 'bg-blue-500 text-white'
-                : 'bg-gray-100 text-gray-700 hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600'
-            }`}
-          >
-            <div className="font-bold">
-              {customer.name}
-              {customer.budgetTier === 'wealthy' && <span className="ml-1">💰</span>}
-              {customer.budgetTier === 'budget' && <span className="ml-1">🪙</span>}
-            </div>
-            <div className="text-sm sm:text-xs opacity-80">
-              {customer.requestRarity} {customer.requestType} • Budget: {customer.maxBudget}g
-            </div>
-          </button>
-        ))}
+      <div className="hidden sm:flex gap-4 overflow-x-auto pb-2">
+        {gameState.customers.filter(c => !c.satisfied).map(customer => {
+          const prof = PROFESSION_STYLES[customer.profession] || {};
+          return (
+            <button
+              key={customer.id}
+              onClick={() => {
+                setSelectedCustomer(customer);
+                setSellingTab(customer.requestType);
+              }}
+              className={`relative p-2 rounded-lg flex flex-col items-center min-h-[64px] min-w-[64px] transition-colors ${
+                selectedCustomer?.id === customer.id
+                  ? 'ring-2 ring-blue-500'
+                  : 'bg-gray-100 hover:bg-gray-200 dark:bg-gray-700 dark:hover:bg-gray-600'
+              } ${prof.border || ''}`}
+            >
+              <div className="relative mb-1">
+                <span className="text-3xl" aria-hidden="true">{prof.icon || '🙂'}</span>
+                <div className="absolute -top-1 -right-1 bg-white border rounded px-1 text-xs">
+                  {ITEM_TYPE_ICONS[customer.requestType]} {RARITY_GEMS[customer.requestRarity]}
+                </div>
+              </div>
+              <div className="w-2 h-10 bg-yellow-200 rounded overflow-hidden mb-1">
+                <div
+                  className="bg-yellow-500 w-full"
+                  style={{ height: BUDGET_HEIGHT[customer.budgetTier] || '50%' }}
+                />
+              </div>
+              <div className="text-xs text-center font-bold">
+                {customer.name}
+              </div>
+            </button>
+          );
+        })}
       </div>
 
       {gameState.customers.filter(c => c.satisfied).length > 0 && (


### PR DESCRIPTION
## Summary
- restyle card headers to be icon-first with status dots and craft progress bars
- show phase timeline and visual material/inventory stacks
- display customers as avatar cards with request and budget icons

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_689618a83a50832099387c8f13c11c5f