### PR TITLE
Enhance material inventory visuals and layout

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7,6 +7,7 @@ import InventoryPanel from './features/InventoryPanel';
 import EventLog from './components/EventLog';
 import Notifications from './components/Notifications';
 import Button from './components/Button';
+import MaterialCard from './components/MaterialCard';
 import GestureHandler from './components/GestureHandler';
 import useCrafting from './hooks/useCrafting';
 import useCustomers from './hooks/useCustomers';
@@ -178,6 +179,17 @@ const MerchantsMorning = () => {
       case 'common':
       default: return 'text-gray-600 bg-gray-100 border-gray-200';
     }
+  };
+  const getCategoryIcon = (type) => {
+    const icons = {
+      metal: '⛓️',
+      wood: '🪵',
+      cloth: '🧵',
+      gem: '💎',
+      leather: '🪶',
+      other: '📦',
+    };
+    return icons[type] || '📦';
   };
 
   const {
@@ -462,35 +474,22 @@ const MerchantsMorning = () => {
                   />
                   {getCardState('materials').expanded && (
                     <CardContent expanded={getCardState('materials').expanded}>
-                      {Object.keys(materialsByType).length > 0 ? (
-                        Object.entries(materialsByType).map(([type, mats]) => (
-                          <div key={type} className="mb-2">
-                            <h4 className="font-semibold text-sm mb-1 capitalize">{type}</h4>
-                            <div className="grid grid-cols-2 sm:grid-cols-4 gap-2">
-                              {mats.map(({ id, count, material }) => (
-                                <div
-                                  key={id}
-                                  className={`relative flex flex-col items-center justify-end h-16 border rounded ${getRarityColor(material.rarity)}`}
-                                >
-                                  <div className="flex flex-col-reverse items-center">
-                                    {Array.from({ length: Math.min(count, 5) }).map((_, i) => (
-                                      <span key={i} className="leading-none text-lg">
-                                        {material.icon}
-                                      </span>
-                                    ))}
-                                  </div>
-                                  {count > 5 && (
-                                    <span className="absolute top-1 right-1 text-xs">+{count - 5}</span>
-                                  )}
-                                  <span className="sr-only">{material.name}: {count}</span>
-                                </div>
-                              ))}
-                            </div>
-                          </div>
-                        ))
-                      ) : (
-                        <p className="text-sm text-gray-600 dark:text-gray-300">No materials</p>
-                      )}
+            {Object.keys(materialsByType).length > 0 ? (
+              <div className="material-categories space-y-2">
+                {Object.entries(materialsByType).map(([type, mats]) => (
+                  <div key={type} className="category-row flex items-start gap-2">
+                    <div className="category-icon text-lg">{getCategoryIcon(type)}</div>
+                    <div className="materials-row flex flex-wrap gap-2">
+                      {mats.map(({ id, count, material }) => (
+                        <MaterialCard key={id} material={material} count={count} />
+                      ))}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <p className="text-sm text-gray-600 dark:text-gray-300">No materials</p>
+            )}
                     </CardContent>
                   )}
                 </Card>
@@ -600,17 +599,13 @@ const MerchantsMorning = () => {
 
               <div className="fixed bottom-0 left-0 right-0 bg-white border-t shadow-lg pb-safe dark:bg-gray-800 dark:border-gray-700">
                 <div className="max-w-6xl mx-auto flex items-center h-[70px]">
-                  <div className="flex items-center gap-3 overflow-x-auto flex-[7] px-4 min-w-0">
-                    {getTopMaterials().map(([materialId, count]) => {
-                      const material = MATERIALS[materialId];
-                      return (
-                        <div key={materialId} className="flex items-center gap-1 text-lg whitespace-nowrap flex-shrink-0">
-                          <span>{material.icon}</span>
-                          <span className="font-medium">{count}</span>
-                        </div>
-                      );
-                    })}
-                  </div>
+                    <div className="resource-summary-text flex items-center gap-3 overflow-x-auto flex-[7] px-4 min-w-0">
+                      {getTopMaterials().map(([materialId, count]) => (
+                        <span key={materialId} className="resource-chip flex items-center gap-1 text-lg whitespace-nowrap flex-shrink-0">
+                          {MATERIALS[materialId].icon} {count}
+                        </span>
+                      ))}
+                    </div>
                   <div className="flex-[3] px-4 border-l border-gray-400/30 dark:border-white/20 flex items-center">
                     {gameState.phase === PHASES.MORNING && (
                       <Button

--- a/src/components/MaterialCard.jsx
+++ b/src/components/MaterialCard.jsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const MaterialCard = ({ material, count }) => (
+  <div className={`material-card rarity-${material.rarity}`}>
+    <div className="visual-stack">
+      {Array.from({ length: Math.min(count, 5) }).map((_, i) => (
+        <div
+          key={i}
+          className="stack-item"
+          style={{
+            transform: `translateY(${i * -4}px) translateX(${i * 2}px)`,
+            zIndex: 10 - i,
+            opacity: 1 - i * 0.1,
+            filter: `drop-shadow(${i}px ${i}px 2px rgba(0,0,0,0.3))`,
+          }}
+        >
+          <span className="text-xl leading-none">{material.icon}</span>
+        </div>
+      ))}
+      {count > 5 && <span className="more-indicator">...</span>}
+    </div>
+    <span className="quantity-badge">{count}</span>
+      <div className="material-info">
+        <span className="material-name">{material.name}</span>
+        <span className="quantity">{count}</span>
+      </div>
+  </div>
+);
+
+MaterialCard.propTypes = {
+  material: PropTypes.shape({
+    icon: PropTypes.node,
+    name: PropTypes.string,
+    rarity: PropTypes.string,
+  }).isRequired,
+  count: PropTypes.number.isRequired,
+};
+
+export default MaterialCard;

--- a/src/index.css
+++ b/src/index.css
@@ -261,3 +261,71 @@ textarea:focus {
 .success-glow {
   box-shadow: 0 0 0 4px rgba(16, 185, 129, 0.5);
 }
+
+/* Material card styles */
+.material-card {
+  border-radius: 12px;
+  background: linear-gradient(135deg, #fff 0%, #f8f9fa 100%);
+  border: 2px solid transparent;
+  transition: all 0.2s ease;
+  width: 4rem;
+  height: 5rem;
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-end;
+}
+
+.material-card .visual-stack {
+  position: relative;
+  width: 2rem;
+  height: 2rem;
+}
+
+.material-card .stack-item {
+  position: absolute;
+  top: 0;
+  left: 0;
+}
+
+.material-card .quantity-badge {
+  position: absolute;
+  top: -4px;
+  right: -4px;
+  background: rgba(0,0,0,0.7);
+  color: #fff;
+  font-size: 0.75rem;
+  padding: 0 4px;
+  border-radius: 9999px;
+}
+
+.material-card .more-indicator {
+  position: absolute;
+  bottom: -6px;
+  right: -6px;
+  font-size: 0.75rem;
+}
+
+.material-card .material-info {
+  text-align: center;
+  font-size: 0.75rem;
+  margin-top: 0.25rem;
+}
+
+.material-card.rarity-common {
+  border-color: #6c757d;
+  background: linear-gradient(135deg, #f8f9fa 0%, #e9ecef 100%);
+}
+
+.material-card.rarity-uncommon {
+  border-color: #28a745;
+  background: linear-gradient(135deg, #d4edda 0%, #c3e6cb 100%);
+  box-shadow: 0 2px 8px rgba(40, 167, 69, 0.2);
+}
+
+.material-card.rarity-rare {
+  border-color: #6f42c1;
+  background: linear-gradient(135deg, #e2d9f3 0%, #d1c4e9 100%);
+  box-shadow: 0 2px 8px rgba(111, 66, 193, 0.2);
+}


### PR DESCRIPTION
## Summary
- introduce MaterialCard with stacked icons and quantity badge
- restructure materials section into category rows with icons
- streamline bottom bar resource summary

## Testing
- `npm test` *(fails: /usr/bin/env: ‘npm’: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6896226699848320af051c3851dece8f