### PR TITLE
Arrange supply boxes grid, enable empty stall tabs, add floating next-phase button

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef, useCallback, useMemo } from 'react';
-import { Coins, AlertCircle, Sun, Moon, Menu, BookOpen, Settings, HelpCircle } from 'lucide-react';
+import { Coins, AlertCircle, Sun, Moon, Menu, BookOpen, Settings, HelpCircle, ArrowRight } from 'lucide-react';
 import { PHASES, BOX_TYPES, RECIPES } from './constants';
 import { Card, CardHeader, CardContent } from './components/Card';
 import Workshop from './features/Workshop';
@@ -208,27 +208,30 @@ const MerchantsMorning = () => {
   const inventoryStatus = getCardStatus('inventory', gameState);
   const customerQueueStatus = getCardStatus('customerQueue', gameState);
 
+  const advancePhase = useCallback(() => {
+    switch (gameState.phase) {
+      case PHASES.MORNING:
+        setGameState(prev => ({ ...prev, phase: PHASES.CRAFTING }));
+        addNotification('⚒️ Advanced to Crafting', 'info');
+        break;
+      case PHASES.CRAFTING:
+        openShop();
+        break;
+      case PHASES.SHOPPING:
+        endDay();
+        break;
+      case PHASES.END_DAY:
+        startNewDay();
+        break;
+      default:
+        break;
+    }
+  }, [gameState.phase, setGameState, addNotification, openShop, endDay, startNewDay]);
+
   // NEW: Gesture handlers
   const handleSwipeGesture = useCallback((direction) => {
     if (direction === 'left') {
-      // Advance to next phase
-      switch (gameState.phase) {
-        case PHASES.MORNING:
-          setGameState(prev => ({ ...prev, phase: PHASES.CRAFTING }));
-          addNotification('⚒️ Swiped to Crafting', 'info');
-          break;
-        case PHASES.CRAFTING:
-          openShop();
-          break;
-        case PHASES.SHOPPING:
-          endDay();
-          break;
-        case PHASES.END_DAY:
-          startNewDay();
-          break;
-        default:
-          break;
-      }
+      advancePhase();
     } else if (direction === 'right') {
       // Go to previous phase (limited)
       switch (gameState.phase) {
@@ -244,7 +247,7 @@ const MerchantsMorning = () => {
           break;
       }
     }
-  }, [gameState.phase, setGameState, addNotification, openShop, endDay, startNewDay]);
+  }, [advancePhase, gameState.phase, setGameState, addNotification]);
 
   const handleCardSwipe = useCallback((direction, cardId) => {
     if (direction === 'left') {
@@ -398,7 +401,7 @@ const MerchantsMorning = () => {
                   />
                   {getCardState('supplyBoxes').expanded && (
                     <CardContent expanded={getCardState('supplyBoxes').expanded}>
-                      <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+                      <div className="grid grid-cols-3 gap-3">
                         {Object.entries(BOX_TYPES).map(([type, box]) => (
                           <div key={type} className="border rounded-lg p-3 text-center hover:bg-gray-50 dark:border-gray-700 dark:hover:bg-gray-700">
                             <h3 className="font-bold capitalize text-sm mb-1">{box.name}</h3>
@@ -547,6 +550,13 @@ const MerchantsMorning = () => {
             <EndOfDaySummary gameState={gameState} />
           )}
         </GestureHandler>
+        <button
+          onClick={advancePhase}
+          className="fixed bottom-4 right-4 bg-blue-600 hover:bg-blue-700 text-white p-4 rounded-full shadow-lg"
+          aria-label="Advance to next phase"
+        >
+          <ArrowRight className="w-5 h-5" />
+        </button>
       </div>
   );
 };

--- a/src/features/MaterialStallsPanel.jsx
+++ b/src/features/MaterialStallsPanel.jsx
@@ -9,13 +9,18 @@ const MaterialStallsPanel = ({ gameState, getRarityColor }) => {
   const { materialsByStall, getStallMaterialCount, getActiveStalls } = useMaterialStalls(gameState.materials);
   const activeStalls = getActiveStalls();
   const [activeStall, setActiveStall] = useState(activeStalls[0] || 'blacksmith');
+  const [manualSelection, setManualSelection] = useState(false);
 
-  // Switch to first available stall if current one becomes empty
+  // Switch to first available stall if current one becomes empty, but allow manual selection of empty stalls
   React.useEffect(() => {
+    if (manualSelection) {
+      setManualSelection(false);
+      return;
+    }
     if (activeStalls.length > 0 && !activeStalls.includes(activeStall)) {
       setActiveStall(activeStalls[0]);
     }
-  }, [activeStalls, activeStall]);
+  }, [activeStalls, activeStall, manualSelection]);
 
   const activeStallData = MERCHANT_STALLS[activeStall];
   const activeMaterials = materialsByStall[activeStall] || [];
@@ -32,7 +37,10 @@ const MaterialStallsPanel = ({ gameState, getRarityColor }) => {
               stall={stall}
               isActive={activeStall === stallId}
               materialCount={materialCount}
-              onClick={() => setActiveStall(stallId)}
+              onClick={() => {
+                setActiveStall(stallId);
+                setManualSelection(true);
+              }}
             />
           );
         })}


### PR DESCRIPTION
## Summary
- display supply boxes in a compact 3x2 grid
- allow switching to stalls with no materials and show empty state
- add floating button to advance the game to the next phase

## Testing
- `npm test --silent -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_6896445eda1c83208e675e455266459f