### PR TITLE
Fix stall selection and supply box alignment

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -404,7 +404,7 @@ const MerchantsMorning = () => {
                       <div className="grid grid-cols-3 gap-3">
                         {Object.entries(BOX_TYPES).map(([type, box]) => (
                           <div key={type} className="border rounded-lg p-3 text-center hover:bg-gray-50 dark:border-gray-700 dark:hover:bg-gray-700">
-                            <h3 className="font-bold capitalize text-sm mb-1">{box.name}</h3>
+                            <h3 className="font-bold capitalize text-sm mb-1 h-10 flex items-center justify-center">{box.name}</h3>
                             <p className="text-sm sm:text-xs text-gray-600 mb-2 dark:text-gray-300">
                               {box.materialCount[0]}-{box.materialCount[1]} materials
                             </p>

--- a/src/features/MaterialStallsPanel.jsx
+++ b/src/features/MaterialStallsPanel.jsx
@@ -11,14 +11,14 @@ const MaterialStallsPanel = ({ gameState, getRarityColor }) => {
   const [activeStall, setActiveStall] = useState(activeStalls[0] || 'blacksmith');
   const [manualSelection, setManualSelection] = useState(false);
 
-  // Switch to first available stall if current one becomes empty, but allow manual selection of empty stalls
+  // Switch to first available stall if current one becomes empty, unless user manually selected an empty stall
   React.useEffect(() => {
-    if (manualSelection) {
-      setManualSelection(false);
-      return;
-    }
-    if (activeStalls.length > 0 && !activeStalls.includes(activeStall)) {
+    if (!manualSelection && activeStalls.length > 0 && !activeStalls.includes(activeStall)) {
       setActiveStall(activeStalls[0]);
+    }
+
+    if (activeStalls.includes(activeStall)) {
+      setManualSelection(false);
     }
   }, [activeStalls, activeStall, manualSelection]);
 


### PR DESCRIPTION
## Summary
- keep manually selected empty stalls active
- align supply box headers for consistent layout

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_689647774914832086a63cde55bc6957