### PR TITLE
feat: improve PWA update flow on iOS

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -97,3 +97,13 @@ All game data is in `src/App.js`:
 - Optimized for mobile performance
 
 Built with React 18 and modern PWA standards.
+## 🔄 PWA Updates
+
+The app checks for service worker updates on load and whenever it returns to the foreground. If a new version is available, an **Update available** toast appears. Tap **Update** to activate the fresh service worker and reload without losing saved data.
+
+### Testing on iOS
+1. Install the app via **Add to Home Screen**.
+2. Deploy a new version.
+3. Open the installed app, background it, then return to trigger an update check.
+4. When the toast appears, tap **Update** and confirm your progress persists.
+

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -16,6 +16,7 @@ import ShopInterface from './features/ShopInterface';
 import EndOfDaySummary from './features/EndOfDaySummary';
 import useCardIntelligence from './hooks/useCardIntelligence';
 import generateId from './utils/id';
+import UpdateToast from './components/UpdateToast';
 
 const MerchantsMorning = () => {
   const [gameState, setGameState, resetGame] = useGameState();
@@ -553,6 +554,7 @@ const MerchantsMorning = () => {
         >
           <ArrowRight className="w-5 h-5" />
         </button>
+          <UpdateToast />
       </div>
   );
 };

--- a/src/components/UpdateToast.jsx
+++ b/src/components/UpdateToast.jsx
@@ -1,0 +1,35 @@
+import React, { useEffect, useState } from 'react';
+
+const UpdateToast = () => {
+  const [reg, setReg] = useState(null);
+
+  useEffect(() => {
+    function onUpdate(e) {
+      setReg(e.detail.reg);
+    }
+    window.addEventListener('pwa-update-available', onUpdate);
+    return () => window.removeEventListener('pwa-update-available', onUpdate);
+  }, []);
+
+  const applyUpdate = () => {
+    if (reg && reg.waiting) {
+      reg.waiting.postMessage({ type: 'SKIP_WAITING' });
+    }
+  };
+
+  if (!reg) return null;
+
+  return (
+    <div className="fixed bottom-4 left-1/2 -translate-x-1/2 bg-gray-800 text-white px-4 py-2 rounded shadow-lg flex items-center space-x-2 z-50">
+      <span>Update available</span>
+      <button
+        onClick={applyUpdate}
+        className="bg-blue-600 hover:bg-blue-700 text-white px-2 py-1 rounded"
+      >
+        Update
+      </button>
+    </div>
+  );
+};
+
+export default UpdateToast;

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,9 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 import App from './App';
-import * as serviceWorkerRegistration from './serviceWorkerRegistration';
+import { migrateStorage } from './utils/storageMigrations';
+
+migrateStorage();
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
@@ -11,4 +13,38 @@ root.render(
   </React.StrictMode>
 );
 
-serviceWorkerRegistration.register();
+if ('serviceWorker' in navigator) {
+  window.addEventListener('load', async () => {
+    try {
+      const reg = await navigator.serviceWorker.register('/service-worker.js', {
+        updateViaCache: 'none'
+      });
+
+      reg.update();
+      document.addEventListener('visibilitychange', () => {
+        if (document.visibilityState === 'visible') reg.update();
+      });
+
+      reg.addEventListener('updatefound', () => {
+        const newSW = reg.installing;
+        if (!newSW) return;
+        newSW.addEventListener('statechange', () => {
+          if (newSW.state === 'installed' && navigator.serviceWorker.controller) {
+            window.dispatchEvent(
+              new CustomEvent('pwa-update-available', { detail: { reg } })
+            );
+          }
+        });
+      });
+
+      let refreshing = false;
+      navigator.serviceWorker.addEventListener('controllerchange', () => {
+        if (refreshing) return;
+        refreshing = true;
+        window.location.reload();
+      });
+    } catch (e) {
+      console.error('SW registration failed', e);
+    }
+  });
+}

--- a/src/service-worker.js
+++ b/src/service-worker.js
@@ -1,5 +1,17 @@
 /* eslint-disable no-restricted-globals */
 /* eslint-disable no-undef */
 import { precacheAndRoute } from 'workbox-precaching';
+import { clientsClaim } from 'workbox-core';
 
+self.addEventListener('message', (event) => {
+  if (event.data && event.data.type === 'SKIP_WAITING') {
+    self.skipWaiting();
+  }
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(self.clients.claim());
+});
+
+clientsClaim();
 precacheAndRoute(self.__WB_MANIFEST);

--- a/src/utils/storageMigrations.js
+++ b/src/utils/storageMigrations.js
@@ -1,0 +1,22 @@
+export const APP_STORAGE_VERSION = 1;
+
+export function safeGetJSON(key, fallback) {
+  try {
+    return JSON.parse(window.localStorage.getItem(key)) ?? fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+export function migrateStorage() {
+  const meta = safeGetJSON('app_meta', { version: 1 });
+  if (meta.version < APP_STORAGE_VERSION) {
+    const state = safeGetJSON('app_state', {});
+    // Perform non-destructive transformations here
+    window.localStorage.setItem('app_state', JSON.stringify(state));
+    window.localStorage.setItem(
+      'app_meta',
+      JSON.stringify({ version: APP_STORAGE_VERSION })
+    );
+  }
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,28 @@
+{
+  "headers": [
+    {
+      "source": "/sw.js",
+      "headers": [
+        { "key": "Cache-Control", "value": "no-store, must-revalidate" }
+      ]
+    },
+    {
+      "source": "/service-worker.js",
+      "headers": [
+        { "key": "Cache-Control", "value": "no-store, must-revalidate" }
+      ]
+    },
+    {
+      "source": "/manifest.json",
+      "headers": [
+        { "key": "Cache-Control", "value": "no-store, must-revalidate" }
+      ]
+    },
+    {
+      "source": "/index.html",
+      "headers": [
+        { "key": "Cache-Control", "value": "no-cache" }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- configure Vercel headers to disable caching for service worker, manifest and index
- register service worker with proactive update checks and reload on controller change
- add UpdateToast component and storage migration utilities to apply updates without losing data

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68975288b61c8320a8357b1f1dfcf603