### PR TITLE
Align inventory tab styling and disable swipe collapse

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -251,9 +251,7 @@ const MerchantsMorning = () => {
   }, [advancePhase, gameState.phase, setGameState, addNotification]);
 
   const handleCardSwipe = useCallback((direction, cardId) => {
-    if (direction === 'left') {
-      updateCardState(cardId, { expanded: false });
-    } else if (direction === 'right') {
+    if (direction === 'right') {
       updateCardState(cardId, { expanded: true });
       trackCardUsage(cardId, 'expand');
     }

--- a/src/features/InventoryPanel.jsx
+++ b/src/features/InventoryPanel.jsx
@@ -24,7 +24,7 @@ const InventoryPanel = ({
 
   return (
     <div>
-      <div className="flex gap-1 mb-3 overflow-x-auto pb-1">
+      <div className="flex gap-2 overflow-x-auto pb-2">
         {ITEM_TYPES.map(type => {
           const count = filterInventoryByType(type).length;
           return (
@@ -35,7 +35,8 @@ const InventoryPanel = ({
               count={count}
               aria-label={type.charAt(0).toUpperCase() + type.slice(1)}
             >
-              {ITEM_TYPE_ICONS[type]}
+              <div className="tab-icon">{ITEM_TYPE_ICONS[type]}</div>
+              <div className="tab-name capitalize">{type}</div>
             </TabButton>
           );
         })}


### PR DESCRIPTION
## Summary
- Match inventory tab buttons with material panel styling for uniform padding and labels
- Prevent swiping left from collapsing cards

## Testing
- `CI=true npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68975a0fe40c83209e703384c8dce969