### PR TITLE
Fix automatic customer queue expansion during shopping phase

### DIFF
--- a/src/hooks/useCardIntelligence.js
+++ b/src/hooks/useCardIntelligence.js
@@ -1,6 +1,6 @@
 import { useCallback, useState, useEffect, useRef } from 'react';
 import { getDefaultCardStatesForPhase, getCardRelevanceScore } from '../utils/cardContext';
-import { BOX_TYPES } from '../constants';
+import { BOX_TYPES, PHASES } from '../constants';
 
 // Hook to manage smart card behaviour
 const useCardIntelligence = (gameState, userPreferences = {}, setGameState) => {
@@ -38,6 +38,14 @@ const useCardIntelligence = (gameState, userPreferences = {}, setGameState) => {
       return merged;
     });
   }, [gameState.phase, userPreferences]);
+
+  // Forced customer queue updates when shop opens
+  useEffect(() => {
+    if (gameState.forceCustomerQueueUpdate && gameState.phase === PHASES.SHOPPING) {
+      updateCardState('customerQueue', { expanded: true, hidden: false });
+      setGameState(prev => ({ ...prev, forceCustomerQueueUpdate: false }));
+    }
+  }, [gameState.forceCustomerQueueUpdate, gameState.phase, updateCardState, setGameState]);
 
   // Auto-expand based on game events
   useEffect(() => {

--- a/src/hooks/useCustomers.js
+++ b/src/hooks/useCustomers.js
@@ -135,7 +135,8 @@ const useCustomers = (gameState, setGameState, addEvent, addNotification, setSel
     setGameState(prev => ({
       ...prev,
       phase: PHASES.SHOPPING,
-      customers
+      customers,
+      forceCustomerQueueUpdate: true // Add this flag
     }));
     addEvent(`Shop opened with ${customers.length} customers waiting`, 'info');
     addNotification('🛒 Shop opened', 'info');


### PR DESCRIPTION
## Summary
- ensure openShop sets a force flag to trigger customer queue display
- update card intelligence to react to the flag and open the queue

## Testing
- `npm test --silent -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_6897631fee408320a8e21258aef4dda9