### PR TITLE
Fix customer queue auto display in shopping phase

### DIFF
--- a/src/hooks/useCardIntelligence.js
+++ b/src/hooks/useCardIntelligence.js
@@ -1,6 +1,6 @@
 import { useCallback, useState, useEffect, useRef } from 'react';
 import { getDefaultCardStatesForPhase, getCardRelevanceScore } from '../utils/cardContext';
-import { BOX_TYPES } from '../constants';
+import { BOX_TYPES, PHASES } from '../constants';
 
 // Hook to manage smart card behaviour
 const useCardIntelligence = (gameState, userPreferences = {}, setGameState) => {
@@ -91,6 +91,14 @@ const useCardIntelligence = (gameState, userPreferences = {}, setGameState) => {
       updateCardState('customerQueue', { expanded: true, userModified: false });
     }
   }, [gameState.customers, gameState.phase, updateCardState, getCardState]);
+
+  // Force customer queue update when flag is set
+  useEffect(() => {
+    if (gameState.forceCustomerQueueUpdate && gameState.phase === PHASES.SHOPPING) {
+      updateCardState('customerQueue', { expanded: true, hidden: false });
+      setGameState(prev => ({ ...prev, forceCustomerQueueUpdate: false }));
+    }
+  }, [gameState.forceCustomerQueueUpdate, gameState.phase, updateCardState, setGameState]);
 
   const getStoredUsage = () => {
     if (typeof window === 'undefined') return {};

--- a/src/hooks/useCustomers.js
+++ b/src/hooks/useCustomers.js
@@ -135,7 +135,8 @@ const useCustomers = (gameState, setGameState, addEvent, addNotification, setSel
     setGameState(prev => ({
       ...prev,
       phase: PHASES.SHOPPING,
-      customers
+      customers,
+      forceCustomerQueueUpdate: true
     }));
     addEvent(`Shop opened with ${customers.length} customers waiting`, 'info');
     addNotification('🛒 Shop opened', 'info');


### PR DESCRIPTION
## Summary
- ensure opening shop sets a flag to force customer queue update
- auto-expand customer queue in card intelligence when flag is present

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6897631fee408320a8e21258aef4dda9