### PR TITLE
Refine swipe gestures to avoid scroll conflicts

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -250,29 +250,13 @@ const MerchantsMorning = () => {
     }
   }, [advancePhase, gameState.phase, setGameState, addNotification]);
 
-  const handleCardSwipe = useCallback((direction, cardId) => {
-    if (direction === 'left') {
-      updateCardState(cardId, { expanded: false });
-    } else if (direction === 'right') {
-      updateCardState(cardId, { expanded: true });
-      trackCardUsage(cardId, 'expand');
-    }
-  }, [updateCardState, trackCardUsage]);
-
 
 
   return (
     <div className="min-h-screen bg-gradient-to-b from-amber-50 to-orange-100 pb-20 pb-safe dark:from-gray-900 dark:to-gray-800 dark:text-gray-100">
       <Notifications notifications={notifications} />
       <GestureHandler
-        onSwipe={(direction, e, startEl) => {
-          const card = (startEl || e.target).closest('[data-card-id]');
-          if (card) {
-            handleCardSwipe(direction, card.dataset.cardId);
-          } else {
-            handleSwipeGesture(direction);
-          }
-        }}
+        onSwipe={handleSwipeGesture}
         className="max-w-6xl mx-auto p-3"
       >
         <div className="bg-white rounded-lg shadow-lg p-3 mb-3 dark:bg-gray-800">

--- a/src/hooks/useGestures.js
+++ b/src/hooks/useGestures.js
@@ -13,9 +13,17 @@ const useGestures = (ref, options = {}) => {
     let longPressTimer = null;
     let isLongPress = false;
     let startTarget = null;
+    let allowSwipe = false;
 
     const handleTouchStart = (e) => {
       const touch = e.touches[0];
+      const isEdgeSwipe =
+        touch.clientX < 50 || touch.clientX > window.innerWidth - 50;
+      if (!isEdgeSwipe) {
+        allowSwipe = false;
+        return;
+      }
+      allowSwipe = true;
       startX = touch.clientX;
       startY = touch.clientY;
       startTime = Date.now();
@@ -38,6 +46,7 @@ const useGestures = (ref, options = {}) => {
     };
 
     const handleTouchMove = (e) => {
+      if (!allowSwipe) return;
       if (longPressTimer) {
         clearTimeout(longPressTimer);
       }
@@ -56,6 +65,7 @@ const useGestures = (ref, options = {}) => {
       }
 
       if (isLongPress) return;
+      if (!allowSwipe) return;
 
       const touch = e.changedTouches[0];
       const dx = touch.clientX - startX;
@@ -74,6 +84,7 @@ const useGestures = (ref, options = {}) => {
           navigator.vibrate(25);
         }
       }
+      allowSwipe = false;
     };
 
     el.addEventListener('touchstart', handleTouchStart, { passive: false });


### PR DESCRIPTION
## Summary
- Remove card-level swipe handling and limit gesture handler to phase navigation
- Trigger swipe navigation only when touch starts near screen edges

## Testing
- `npm test --silent -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_689764c0d47c83209a65b2be5bcff319