### PR TITLE
Refine swipe handling to prevent tab scroll conflicts

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -249,30 +249,11 @@ const MerchantsMorning = () => {
       }
     }
   }, [advancePhase, gameState.phase, setGameState, addNotification]);
-
-  const handleCardSwipe = useCallback((direction, cardId) => {
-    if (direction === 'left') {
-      updateCardState(cardId, { expanded: false });
-    } else if (direction === 'right') {
-      updateCardState(cardId, { expanded: true });
-      trackCardUsage(cardId, 'expand');
-    }
-  }, [updateCardState, trackCardUsage]);
-
-
-
   return (
     <div className="min-h-screen bg-gradient-to-b from-amber-50 to-orange-100 pb-20 pb-safe dark:from-gray-900 dark:to-gray-800 dark:text-gray-100">
       <Notifications notifications={notifications} />
       <GestureHandler
-        onSwipe={(direction, e, startEl) => {
-          const card = (startEl || e.target).closest('[data-card-id]');
-          if (card) {
-            handleCardSwipe(direction, card.dataset.cardId);
-          } else {
-            handleSwipeGesture(direction);
-          }
-        }}
+        onSwipe={handleSwipeGesture}
         className="max-w-6xl mx-auto p-3"
       >
         <div className="bg-white rounded-lg shadow-lg p-3 mb-3 dark:bg-gray-800">

--- a/src/hooks/useGestures.js
+++ b/src/hooks/useGestures.js
@@ -13,9 +13,13 @@ const useGestures = (ref, options = {}) => {
     let longPressTimer = null;
     let isLongPress = false;
     let startTarget = null;
+    let edgeSwipe = false;
 
     const handleTouchStart = (e) => {
       const touch = e.touches[0];
+      const isEdgeSwipe = touch.clientX < 50 || touch.clientX > window.innerWidth - 50;
+      if (!isEdgeSwipe) return;
+      edgeSwipe = true;
       startX = touch.clientX;
       startY = touch.clientY;
       startTime = Date.now();
@@ -55,7 +59,7 @@ const useGestures = (ref, options = {}) => {
         clearTimeout(longPressTimer);
       }
 
-      if (isLongPress) return;
+      if (isLongPress || !edgeSwipe) return;
 
       const touch = e.changedTouches[0];
       const dx = touch.clientX - startX;
@@ -66,14 +70,14 @@ const useGestures = (ref, options = {}) => {
       const threshold = options.swipeThreshold || 50;
       const timeThreshold = options.swipeTimeLimit || 300;
 
-      if (dt < timeThreshold && Math.max(absDx, absDy) > threshold && onSwipe) {
-        const direction =
-          absDx > absDy ? (dx > 0 ? 'right' : 'left') : (dy > 0 ? 'down' : 'up');
+      if (dt < timeThreshold && absDx > absDy && absDx > threshold && onSwipe) {
+        const direction = dx > 0 ? 'right' : 'left';
         onSwipe(direction, e, startTarget);
         if (navigator.vibrate) {
           navigator.vibrate(25);
         }
       }
+      edgeSwipe = false;
     };
 
     el.addEventListener('touchstart', handleTouchStart, { passive: false });


### PR DESCRIPTION
## Summary
- Remove card-level swipe gestures so global swipes only navigate phases
- Require edge-originated, horizontal swipes to avoid scroll interference

## Testing
- `npm test --silent` *(fails: npm not installed)*

------
https://chatgpt.com/codex/tasks/task_e_689764c0d47c83209a65b2be5bcff319