### PR TITLE
Refine inventory and negotiation UI

### DIFF
--- a/src/components/Card.jsx
+++ b/src/components/Card.jsx
@@ -61,7 +61,7 @@ export const CardHeader = ({
     <button
       type="button"
       onClick={onToggle}
-      className={`w-full flex items-center justify-between p-4 text-left transition-all duration-200 ${getStatusClass()} ${
+      className={`w-full flex items-center justify-between text-left transition-all duration-200 ${getStatusClass()} ${
         isEmpty ? 'opacity-60' : ''
       } ${animating ? 'animate-pulse' : ''}`}
       aria-expanded={expanded}

--- a/src/components/InventoryItemCard.jsx
+++ b/src/components/InventoryItemCard.jsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { ITEM_TYPE_ICONS } from '../constants';
+
+const InventoryItemCard = ({ recipe, count, getRarityColor }) => (
+  <div className={`inventory-item-card ${getRarityColor(recipe.rarity)}`}>
+    <div className="item-header">
+      <div className="item-name">{recipe.name}</div>
+      <div className={`rarity-badge rarity-${recipe.rarity}`}>{recipe.rarity}</div>
+    </div>
+    <div className="item-visual">
+      <div className="item-icon">{ITEM_TYPE_ICONS[recipe.type]}</div>
+      <div className="stack-indicator">×{count}</div>
+    </div>
+    <div className="item-value">{recipe.sellPrice}g each</div>
+  </div>
+);
+
+InventoryItemCard.propTypes = {
+  recipe: PropTypes.shape({
+    id: PropTypes.string.isRequired,
+    name: PropTypes.string.isRequired,
+    type: PropTypes.string.isRequired,
+    rarity: PropTypes.string.isRequired,
+    sellPrice: PropTypes.number.isRequired,
+  }).isRequired,
+  count: PropTypes.number.isRequired,
+  getRarityColor: PropTypes.func.isRequired,
+};
+
+export default InventoryItemCard;

--- a/src/components/NegotiationPanel.jsx
+++ b/src/components/NegotiationPanel.jsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { MATERIALS } from '../constants';
+
+const NegotiationPanel = ({ customer, item, onAccept, onDecline, onBack }) => (
+  <div className="negotiation-panel">
+    <div className="negotiation-header">
+      <h4>Trade Negotiation with {customer.name}</h4>
+    </div>
+    <div className="trade-offer">
+      <div className="offer-section">
+        <span className="offer-label">Gold Offered:</span>
+        <span className="offer-amount">{customer.maxBudget}g</span>
+      </div>
+      <div className="materials-section">
+        <span className="materials-label">Plus Materials:</span>
+        <div className="materials-list">
+          {customer.materials.map((m, i) => (
+            <div key={i} className="material-offer">
+              <span className="material-icon">{MATERIALS[m.id].icon}</span>
+              <span className="material-name">{MATERIALS[m.id].name}</span>
+              <span className="material-value">(~{m.value}g)</span>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+    <div className="negotiation-actions">
+      <button className="btn-primary" onClick={onAccept}>Accept Deal</button>
+      <button className="btn-danger" onClick={onDecline}>Decline</button>
+      <button className="btn-secondary" onClick={onBack}>Back</button>
+    </div>
+  </div>
+);
+
+NegotiationPanel.propTypes = {
+  customer: PropTypes.shape({
+    name: PropTypes.string.isRequired,
+    maxBudget: PropTypes.number.isRequired,
+    materials: PropTypes.arrayOf(
+      PropTypes.shape({
+        id: PropTypes.string.isRequired,
+        value: PropTypes.number.isRequired,
+      })
+    ).isRequired,
+  }).isRequired,
+  item: PropTypes.object,
+  onAccept: PropTypes.func.isRequired,
+  onDecline: PropTypes.func.isRequired,
+  onBack: PropTypes.func.isRequired,
+};
+
+export default NegotiationPanel;

--- a/src/features/InventoryPanel.jsx
+++ b/src/features/InventoryPanel.jsx
@@ -1,6 +1,7 @@
 import React, { useMemo } from 'react';
 import PropTypes from 'prop-types';
 import TabButton from '../components/TabButton';
+import InventoryItemCard from '../components/InventoryItemCard';
 import { RECIPES, ITEM_TYPES, ITEM_TYPE_ICONS } from '../constants';
 
 const InventoryPanel = ({
@@ -45,24 +46,18 @@ const InventoryPanel = ({
         {sortedInventory.map(([itemId, count]) => {
           const recipe = RECIPES.find(r => r.id === itemId);
           return (
-            <div
+            <InventoryItemCard
               key={itemId}
-              className={`relative flex flex-col items-center justify-end h-20 border rounded ${getRarityColor(recipe.rarity)}`}
-            >
-              <div className="flex flex-col-reverse items-center">
-                {Array.from({ length: Math.min(count, 5) }).map((_, i) => (
-                  <span key={i} className="text-xl leading-none">
-                    {ITEM_TYPE_ICONS[recipe.type]}
-                  </span>
-                ))}
-              </div>
-              {count > 5 && <span className="absolute top-1 right-1 text-xs">+{count - 5}</span>}
-              <span className="sr-only">{recipe.name} x{count}</span>
-            </div>
+              recipe={recipe}
+              count={count}
+              getRarityColor={getRarityColor}
+            />
           );
         })}
         {sortedInventory.length === 0 && (
-          <p className="text-sm sm:text-xs text-gray-500 italic dark:text-gray-400 col-span-full">No {inventoryTab}s crafted yet</p>
+          <p className="text-sm sm:text-xs text-gray-500 italic dark:text-gray-400 col-span-full">
+            No {inventoryTab}s crafted yet
+          </p>
         )}
       </div>
     </div>

--- a/src/features/ShopInterface.jsx
+++ b/src/features/ShopInterface.jsx
@@ -2,7 +2,8 @@ import React, { useMemo, useState } from 'react';
 import PropTypes from 'prop-types';
 import { Store } from 'lucide-react';
 import TabButton from '../components/TabButton';
-import { ITEM_TYPES, RECIPES, PROFESSIONS, MATERIALS, ITEM_TYPE_ICONS } from '../constants';
+import { ITEM_TYPES, RECIPES, PROFESSIONS, ITEM_TYPE_ICONS } from '../constants';
+import NegotiationPanel from '../components/NegotiationPanel';
 
 const PROFESSION_STYLES = {
   knight: { icon: '🛡️', border: 'border-gray-400' },
@@ -227,44 +228,16 @@ const ShopInterface = ({
 
               {selectedCustomer && saleInfo && saleInfo.status === 'cant_afford' ? (
                 negotiatingItem === itemId ? (
-                  <div className="space-y-2">
-                    <p className="text-sm">{selectedCustomer.name} offers:</p>
-                    <ul className="text-sm pl-4 list-disc">
-                      {(selectedCustomer.materials || []).map((m, i) => (
-                        <li key={i}>
-                          {MATERIALS[m.id].icon} {MATERIALS[m.id].name} (~{m.value}g)
-                        </li>
-                      ))}
-                    </ul>
-                    <p className="text-sm font-bold">
-                      Total value: {selectedCustomer.maxBudget}g + materials worth ~
-                      {(selectedCustomer.materials || []).reduce((sum, m) => sum + m.value, 0)}g
-                      = {selectedCustomer.maxBudget + (selectedCustomer.materials || []).reduce((sum, m) => sum + m.value, 0)}g
-                    </p>
-                    <div className="flex gap-2">
-                      <button
-                        onClick={() => {
-                          serveCustomer(selectedCustomer.id, itemId, 'barter');
-                          setNegotiatingItem(null);
-                        }}
-                        className="flex-1 bg-green-500 hover:bg-green-600 text-white py-1 rounded text-sm"
-                      >
-                        Accept Deal
-                      </button>
-                      <button
-                        onClick={() => setNegotiatingItem(null)}
-                        className="flex-1 bg-gray-200 hover:bg-gray-300 text-gray-700 py-1 rounded text-sm dark:bg-gray-600 dark:text-gray-200"
-                      >
-                        Back
-                      </button>
-                      <button
-                        onClick={() => setNegotiatingItem(null)}
-                        className="flex-1 bg-red-200 hover:bg-red-300 text-red-700 py-1 rounded text-sm dark:bg-red-700 dark:text-red-200"
-                      >
-                        Decline
-                      </button>
-                    </div>
-                  </div>
+                  <NegotiationPanel
+                    customer={selectedCustomer}
+                    item={recipe}
+                    onAccept={() => {
+                      serveCustomer(selectedCustomer.id, itemId, 'barter');
+                      setNegotiatingItem(null);
+                    }}
+                    onDecline={() => setNegotiatingItem(null)}
+                    onBack={() => setNegotiatingItem(null)}
+                  />
                 ) : (
                   <div className="space-y-2">
                     <p className="text-sm text-red-600">
@@ -273,19 +246,19 @@ const ShopInterface = ({
                     <div className="flex gap-2">
                       <button
                         onClick={() => serveCustomer(selectedCustomer.id, itemId, 'accept_lower')}
-                        className="flex-1 bg-yellow-500 hover:bg-yellow-600 text-white py-1 rounded text-sm"
+                        className="flex-1 btn-primary"
                       >
                         Accept {selectedCustomer.maxBudget}g Only
                       </button>
                       <button
                         onClick={() => setNegotiatingItem(itemId)}
-                        className="flex-1 bg-blue-500 hover:bg-blue-600 text-white py-1 rounded text-sm"
+                        className="flex-1 btn-secondary"
                       >
                         Negotiate Trade
                       </button>
                       <button
                         onClick={() => setNegotiatingItem(null)}
-                        className="flex-1 bg-red-200 hover:bg-red-300 text-red-700 py-1 rounded text-sm dark:bg-red-700 dark:text-red-200"
+                        className="flex-1 btn-danger"
                       >
                         Decline
                       </button>

--- a/src/index.css
+++ b/src/index.css
@@ -3,6 +3,13 @@
 @tailwind utilities;
 
 /* Reset and base styles */
+:root {
+  --card-padding: 16px;
+  --card-gap: 12px;
+  --card-border-radius: 12px;
+  --header-height: 64px;
+}
+
 * {
   box-sizing: border-box;
 }
@@ -221,6 +228,12 @@ textarea:focus {
     transform: scaleY(0.3);
     opacity: 0.7;
   }
+}
+
+/* Card header styling */
+.card-header {
+  min-height: var(--header-height);
+  padding: var(--card-padding);
 }
 
 /* Card header status indicators */
@@ -527,6 +540,97 @@ textarea:focus {
 .empty-subtitle {
   font-size: 14px;
   opacity: 0.7;
+}
+
+.inventory-item-card {
+  background: white;
+  border-radius: 12px;
+  padding: 16px;
+  border: 2px solid;
+  transition: all 0.2s ease;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.item-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.item-name {
+  font-weight: bold;
+  font-size: 16px;
+}
+
+.item-visual {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.stack-indicator {
+  font-size: 14px;
+  font-weight: bold;
+}
+
+.item-value {
+  font-size: 14px;
+  color: #2c3e50;
+}
+
+.item-icon {
+  font-size: 32px;
+}
+
+.negotiation-panel {
+  background: linear-gradient(135deg, #f8f9fa 0%, #e9ecef 100%);
+  border: 2px solid #6c757d;
+  border-radius: 16px;
+  padding: 20px;
+  margin: 16px 0;
+}
+
+.trade-offer {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  margin: 16px 0;
+}
+
+.negotiation-actions {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  gap: 12px;
+  margin-top: 20px;
+}
+
+.btn-primary {
+  background: linear-gradient(135deg, #3b82f6, #1d4ed8);
+  color: white;
+  padding: 12px 24px;
+  border-radius: 8px;
+  font-weight: 600;
+  transition: all 0.2s ease;
+}
+
+.btn-secondary {
+  background: linear-gradient(135deg, #6b7280, #4b5563);
+  color: white;
+  padding: 12px 24px;
+  border-radius: 8px;
+  font-weight: 600;
+  transition: all 0.2s ease;
+}
+
+.btn-danger {
+  background: linear-gradient(135deg, #ef4444, #dc2626);
+  color: white;
+  padding: 12px 24px;
+  border-radius: 8px;
+  font-weight: 600;
+  transition: all 0.2s ease;
 }
 
 @media (max-width: 600px) {


### PR DESCRIPTION
## Summary
- Introduce InventoryItemCard for crafted items with rarity badges and value display
- Add NegotiationPanel component and styling to streamline barter interactions
- Standardize card header spacing and add global button styles

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_6897678a36708320a68f795b014e42f7