### PR TITLE
Refine inventory layout and gesture edge detection

### DIFF
--- a/src/features/InventoryPanel.jsx
+++ b/src/features/InventoryPanel.jsx
@@ -42,7 +42,7 @@ const InventoryPanel = ({
         })}
       </div>
 
-        <div className="grid grid-cols-3 sm:grid-cols-4 gap-2 max-h-80 overflow-y-auto">
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 max-h-80 overflow-y-auto">
           {sortedInventory.map(([itemId, count]) => {
             const recipe = RECIPES.find(r => r.id === itemId);
             return (
@@ -55,9 +55,17 @@ const InventoryPanel = ({
             );
           })}
           {sortedInventory.length === 0 && (
-            <p className="text-sm sm:text-xs text-gray-500 italic dark:text-gray-400 col-span-full">
-              No {inventoryTab}s crafted yet
-            </p>
+            <div className="col-span-full">
+              <div className="inventory-item-card border-dashed border-gray-300 bg-gray-50 dark:bg-gray-800 flex flex-col items-center justify-center text-center py-8">
+                <div className="text-4xl mb-2">📦</div>
+                <p className="text-sm text-gray-500 italic dark:text-gray-400">
+                  No {inventoryTab}s crafted yet
+                </p>
+                <p className="text-xs text-gray-400 mt-1 dark:text-gray-500">
+                  Visit the workshop to craft items!
+                </p>
+              </div>
+            </div>
           )}
         </div>
       </div>

--- a/src/hooks/useGestures.js
+++ b/src/hooks/useGestures.js
@@ -17,7 +17,7 @@ const useGestures = (ref, options = {}) => {
 
     const handleTouchStart = (e) => {
       const touch = e.touches[0];
-      const isEdgeSwipe = touch.clientX < 50 || touch.clientX > window.innerWidth - 50;
+      const isEdgeSwipe = touch.clientX < 80 || touch.clientX > window.innerWidth - 80;
       if (!isEdgeSwipe) return;
       edgeSwipe = true;
       startX = touch.clientX;

--- a/src/index.css
+++ b/src/index.css
@@ -568,13 +568,14 @@ textarea:focus {
 
 .inventory-item-card {
   background: white;
-  border-radius: 12px;
-  padding: 16px;
+  border-radius: 8px;
+  padding: 12px;
   border: 2px solid;
   transition: all 0.2s ease;
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: 8px;
+  min-height: 120px;
 }
 
 .item-header {
@@ -585,7 +586,8 @@ textarea:focus {
 
 .item-name {
   font-weight: bold;
-  font-size: 16px;
+  font-size: 14px;
+  line-height: 1.2;
 }
 
 .item-visual {
@@ -627,6 +629,23 @@ textarea:focus {
   grid-template-columns: 1fr 1fr 1fr;
   gap: 12px;
   margin-top: 20px;
+}
+
+@media (max-width: 640px) {
+  .inventory-item-card {
+    padding: 8px;
+    gap: 6px;
+    min-height: 100px;
+  }
+
+  .item-name {
+    font-size: 12px;
+  }
+
+  .negotiation-actions {
+    grid-template-columns: 1fr;
+    gap: 8px;
+  }
 }
 
 @media (max-width: 600px) {


### PR DESCRIPTION
## Summary
- Simplify inventory grid and add styled empty state card
- Tune edge swipe detection for smoother gestures
- Adjust card and negotiation button styles for better mobile fit

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68976cddb3a48320940564cba1959a7d