### PR TITLE
Simplify card state management

### DIFF
--- a/src/components/Card.jsx
+++ b/src/components/Card.jsx
@@ -12,11 +12,12 @@ Card.propTypes = {
   className: PropTypes.string,
 };
 
-export const CardHeader = ({ 
-  icon, 
-  title, 
+export const CardHeader = ({
+  icon,
+  title,
   subtitle,
   expanded,
+  semiExpanded,
   onToggle,
   isEmpty,
   subtitleClassName = '',
@@ -28,14 +29,11 @@ export const CardHeader = ({
   const getStatusClass = () => {
     switch (status) {
       case 'available':
-      case 'ready':
         return 'status-available';
       case 'locked':
         return 'status-locked';
       case 'updated':
         return 'status-updated';
-      case 'vip':
-        return 'status-vip';
       default:
         return '';
     }
@@ -44,14 +42,11 @@ export const CardHeader = ({
   const statusDotColor = () => {
     switch (status) {
       case 'available':
-      case 'ready':
         return 'bg-green-500';
       case 'locked':
         return 'bg-red-500';
       case 'updated':
         return 'bg-blue-500';
-      case 'vip':
-        return 'bg-purple-500';
       default:
         return 'bg-gray-400';
     }
@@ -64,7 +59,7 @@ export const CardHeader = ({
       className={`w-full flex items-center justify-between text-left transition-all duration-200 card-header ${getStatusClass()} ${
         isEmpty ? 'opacity-60' : ''
       } ${animating ? 'animate-pulse' : ''}`}
-      aria-expanded={expanded}
+      aria-expanded={expanded || semiExpanded}
     >
       <div className="flex items-center gap-3">
         <span className="text-2xl" aria-hidden="true">{icon}</span>
@@ -89,7 +84,9 @@ export const CardHeader = ({
       <div className="flex items-center gap-3">
         {subtitle && <span className="sr-only">{subtitle}</span>}
         <span className={`w-3 h-3 rounded-full ${statusDotColor()}`}></span>
-        <span className={`transition-transform duration-200 ${expanded ? 'rotate-180' : ''}`}>▼</span>
+        <span className="transition-transform duration-200">
+          {expanded ? '▲' : semiExpanded ? '▼' : '▶'}
+        </span>
       </div>
     </button>
   );
@@ -100,10 +97,11 @@ CardHeader.propTypes = {
   title: PropTypes.string.isRequired,
   subtitle: PropTypes.string,
   expanded: PropTypes.bool,
+  semiExpanded: PropTypes.bool,
   onToggle: PropTypes.func.isRequired,
   isEmpty: PropTypes.bool,
   subtitleClassName: PropTypes.string,
-  status: PropTypes.oneOf(['normal', 'available', 'locked', 'updated', 'vip', 'ready', 'waiting']),
+  status: PropTypes.oneOf(['normal', 'available', 'locked', 'updated']),
   badge: PropTypes.number,
   animating: PropTypes.bool,
   progress: PropTypes.shape({

--- a/src/hooks/useCardIntelligence.js
+++ b/src/hooks/useCardIntelligence.js
@@ -1,224 +1,110 @@
-import { useCallback, useState, useEffect, useRef } from 'react';
-import { getDefaultCardStatesForPhase, getCardRelevanceScore } from '../utils/cardContext';
-import { BOX_TYPES, PHASES } from '../constants';
+import { useCallback, useEffect, useState } from 'react';
+import { getDefaultCardStatesForPhase } from '../utils/cardContext';
+import { BOX_TYPES } from '../constants';
 
-// Hook to manage smart card behaviour
-const useCardIntelligence = (gameState, userPreferences = {}, setGameState) => {
+const useCardIntelligence = (gameState) => {
   const [cardStates, setCardStates] = useState(() =>
-    getDefaultCardStatesForPhase(gameState.phase, gameState, userPreferences)
+    getDefaultCardStatesForPhase(gameState.phase, gameState)
   );
 
-  const materialsTimerRef = useRef(null);
-  const materialsTokenRef = useRef(0);
+  useEffect(() => {
+    setCardStates(getDefaultCardStatesForPhase(gameState.phase, gameState));
+  }, [gameState.phase, gameState]);
 
   const getCardState = useCallback(
-    (id) => cardStates[id] || { expanded: false, hidden: false },
+    (id) => cardStates[id] || { expanded: false, semiExpanded: false, hidden: false, expandedCategories: [] },
     [cardStates]
   );
 
   const updateCardState = useCallback((id, updates) => {
     setCardStates((prev) => ({
       ...prev,
-      [id]: { ...getCardState(id), ...updates, userModified: updates.userModified ?? true },
+      [id]: { ...getCardState(id), ...updates },
     }));
   }, [getCardState]);
 
-  // Auto-update card states when phase changes
-  useEffect(() => {
-    const newStates = getDefaultCardStatesForPhase(gameState.phase, gameState, userPreferences);
+  const toggleCategory = useCallback((cardId, category) => {
     setCardStates(prev => {
-      const merged = { ...prev };
-      Object.entries(newStates).forEach(([cardId, newState]) => {
-        const userOverride = userPreferences.preferredExpansions?.[gameState.phase]?.includes(cardId);
-        const userModified = prev[cardId]?.userModified === true;
-        if (!userOverride && !userModified) {
-          merged[cardId] = { ...merged[cardId], ...newState };
-        }
-      });
-      return merged;
-    });
-  }, [gameState.phase, userPreferences]);
-
-  // Auto-expand based on game events
-  useEffect(() => {
-    if (!gameState.newMaterialsReceived) return;
-
-    // Clear any existing timer before starting a new cycle
-    if (materialsTimerRef.current) {
-      clearTimeout(materialsTimerRef.current);
-      materialsTimerRef.current = null;
-    }
-
-    // Mark an auto expansion with a fresh token
-    materialsTokenRef.current += 1;
-    const myToken = materialsTokenRef.current;
-
-    updateCardState('materials', { expanded: true, userModified: false });
-    setGameState(prev => ({ ...prev, newMaterialsReceived: false, newMaterialsCount: 0 }));
-
-    materialsTimerRef.current = setTimeout(() => {
-      setCardStates(current => {
-        // Only collapse if this effect instance is still the latest
-        if (materialsTokenRef.current !== myToken) return current;
-        const materialsState = current.materials || {};
-        if (materialsState.expanded && !materialsState.userModified) {
-          return {
-            ...current,
-            materials: { ...materialsState, expanded: false, userModified: false }
-          };
-        }
-        return current;
-      });
-      materialsTimerRef.current = null;
-    }, 3000);
-
-    return () => {
-      if (materialsTimerRef.current) {
-        clearTimeout(materialsTimerRef.current);
-        materialsTimerRef.current = null;
+      const current = prev[cardId] || { expanded: false, semiExpanded: false, hidden: false, expandedCategories: [] };
+      const setCat = new Set(current.expandedCategories || []);
+      if (setCat.has(category)) {
+        setCat.delete(category);
+      } else {
+        setCat.add(category);
       }
-    };
-  }, [gameState.newMaterialsReceived, updateCardState, setCardStates, setGameState]);
-
-  // Auto-expand when customer VIPs arrive
-  useEffect(() => {
-    const vipCustomers = (gameState.customers || []).filter(c => c.budgetTier === 'wealthy');
-    if (vipCustomers.length === 0 || gameState.phase !== 'shopping') return;
-
-    const cq = getCardState('customerQueue');
-    // Only auto-expand if not already expanded and not explicitly user-modified
-    if (!cq.expanded && !cq.userModified) {
-      updateCardState('customerQueue', { expanded: true, userModified: false });
-    }
-  }, [gameState.customers, gameState.phase, updateCardState, getCardState]);
-
-  // Force customer queue update when flag is set
-  useEffect(() => {
-    if (gameState.forceCustomerQueueUpdate && gameState.phase === PHASES.SHOPPING) {
-      updateCardState('customerQueue', { expanded: true, hidden: false });
-      setGameState(prev => ({ ...prev, forceCustomerQueueUpdate: false }));
-    }
-  }, [gameState.forceCustomerQueueUpdate, gameState.phase, updateCardState, setGameState]);
-
-  const getStoredUsage = () => {
-    if (typeof window === 'undefined') return {};
-    try {
-      return JSON.parse(window.localStorage.getItem('cardUsage') || '{}');
-    } catch {
-      return {};
-    }
-  };
-
-  const [, setUsage] = useState(getStoredUsage);
-
-  const getCardPriority = useCallback(
-    (cardType, gs = gameState, userActivity = {}) =>
-      getCardRelevanceScore(cardType, { ...gs, ...userActivity }),
-    [gameState]
-  );
-
-  const addToPreferredExpansions = useCallback((phase, cardId) => {
-    if (!userPreferences.preferredExpansions) {
-      userPreferences.preferredExpansions = {};
-    }
-    const list = new Set(userPreferences.preferredExpansions[phase] || []);
-    list.add(cardId);
-    userPreferences.preferredExpansions[phase] = Array.from(list);
-  }, [userPreferences]);
-
-  const storeUsage = (data) => {
-    if (typeof window === 'undefined') return;
-    try {
-      window.localStorage.setItem('cardUsage', JSON.stringify(data));
-    } catch {
-      /* noop */
-    }
-  };
-
-  const trackCardUsage = useCallback((cardId, action) => {
-    setUsage((prev) => {
-      const usageData = { ...prev };
-      const cardUsage = usageData[cardId] || { expansions: 0, lastUsed: null };
-      if (action === 'expand') {
-        cardUsage.expansions += 1;
-        cardUsage.lastUsed = Date.now();
-        if (cardUsage.expansions > 5) {
-          addToPreferredExpansions(gameState.phase, cardId);
-        }
-      }
-      usageData[cardId] = cardUsage;
-      storeUsage(usageData);
-      return usageData;
+      return {
+        ...prev,
+        [cardId]: { ...current, expandedCategories: Array.from(setCat) }
+      };
     });
-  }, [addToPreferredExpansions, gameState.phase]);
+  }, []);
 
   const getCardStatus = useCallback((cardType, gs = gameState) => {
     switch (cardType) {
       case 'marketNews': {
         const count = (gs.marketReports || []).length;
         return {
-          subtitle: count > 0 ? `${count} report${count !== 1 ? 's' : ''}` : 'No reports today',
           status: count > 0 ? 'updated' : 'locked',
+          subtitle: '',
           badge: count,
         };
       }
       case 'supplyBoxes': {
         const affordable = Object.entries(BOX_TYPES).filter(([, box]) => (gs.gold || 0) >= box.cost);
         return {
-          subtitle: affordable.length > 0
-            ? `${affordable[0][1].name} available`
-            : `Need ${BOX_TYPES.bronze.cost - (gs.gold || 0)}g more`,
           status: affordable.length > 0 ? 'available' : 'locked',
+          subtitle: '',
           badge: affordable.length,
         };
       }
       case 'materials': {
         const total = Object.values(gs.materials || {}).reduce((s, c) => s + c, 0);
-        const newMaterials = gs.newMaterialsCount || 0;
-        const uniqueTypes = Object.keys(gs.materials || {}).filter(id => (gs.materials[id] || 0) > 0).length;
-        
         return {
-          subtitle: `${uniqueTypes} types • ${total} total${newMaterials > 0 ? ` • ${newMaterials} new` : ''}`,
-          status: newMaterials > 0 ? 'updated' : total > 0 ? 'normal' : 'locked',
+          status: total > 0 ? 'available' : 'locked',
+          subtitle: '',
           badge: total,
         };
       }
       case 'workshop': {
         const craftable = gs.craftableCount || 0;
-        const totalRecipes = gs.totalRecipeCount || 0;
         return {
-          subtitle: `${craftable}/${totalRecipes} craftable`,
-          status: craftable > 0 ? 'ready' : 'waiting',
+          status: craftable > 0 ? 'available' : 'locked',
+          subtitle: '',
           badge: craftable,
         };
       }
       case 'inventory': {
         const total = Object.values(gs.inventory || {}).reduce((s, c) => s + c, 0);
         return {
-          subtitle: `${total} items`,
-          status: total > 0 ? 'normal' : 'locked',
+          status: total > 0 ? 'available' : 'locked',
+          subtitle: '',
           badge: total,
         };
       }
       case 'customerQueue': {
-        const waiting = (gs.customers || []).filter(c => !c.satisfied);
-        const vip = waiting.filter(c => c.budgetTier === 'wealthy');
+        const waiting = (gs.customers || []).filter(c => !c.satisfied).length;
         return {
-          subtitle: `${waiting.length} waiting${vip.length > 0 ? ` • ${vip.length} VIP` : ''}`,
-          status: vip.length > 0 ? 'vip' : 'normal',
-          badge: waiting.length,
+          status: waiting > 0 ? 'updated' : 'locked',
+          subtitle: '',
+          badge: waiting,
+        };
+      }
+      case 'daySummary': {
+        return {
+          status: 'updated',
+          subtitle: '',
+          badge: 0,
         };
       }
       default:
-        return { subtitle: '', status: 'normal', badge: 0 };
+        return { status: 'available', subtitle: '', badge: 0 };
     }
   }, [gameState]);
 
   return {
     getCardState,
     updateCardState,
-    getCardPriority,
-    trackCardUsage,
+    toggleCategory,
     getCardStatus,
   };
 };

--- a/src/utils/__tests__/cardContext.test.js
+++ b/src/utils/__tests__/cardContext.test.js
@@ -6,5 +6,6 @@ describe('card context defaults', () => {
     const states = getDefaultCardStatesForPhase(PHASES.SHOPPING);
     expect(states.customerQueue.hidden).toBe(false);
     expect(states.customerQueue.expanded).toBe(true);
+    expect(states.customerQueue.semiExpanded).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- remove user preference tracking and adaptive card behavior
- add new three-state card system with phase-based defaults
- streamline card statuses and expansion logic

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6898ac47be9c8320b9b1aa13b210522d