### PR TITLE
Wire card state to panels

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -362,11 +362,13 @@ const MerchantsMorning = () => {
                 status={materialsStatus.status}
                 badge={materialsStatus.badge}
               />
-              {getCardState('materials').expanded && (
+              {(getCardState('materials').semiExpanded || getCardState('materials').expanded) && (
                 <CardContent expanded={getCardState('materials').expanded}>
                   <MaterialStallsPanel
                     gameState={gameState}
                     getRarityColor={getRarityColor}
+                    cardState={getCardState('materials')}
+                    toggleCategory={toggleCategory}
                   />
                 </CardContent>
               )}
@@ -388,7 +390,7 @@ const MerchantsMorning = () => {
                 progress={{ current: craftableRecipes, total: totalRecipes }}
                 subtitle={workshopStatus.subtitle}
               />
-              {getCardState('workshop').expanded && (
+              {(getCardState('workshop').semiExpanded || getCardState('workshop').expanded) && (
                 <CardContent expanded={getCardState('workshop').expanded}>
                   <Workshop
                     gameState={gameState}
@@ -399,6 +401,8 @@ const MerchantsMorning = () => {
                     filterRecipesByType={filterRecipesByType}
                     sortRecipesByRarityAndCraftability={sortRecipesByRarityAndCraftability}
                     getRarityColor={getRarityColor}
+                    cardState={getCardState('workshop')}
+                    toggleCategory={toggleCategory}
                   />
                 </CardContent>
               )}
@@ -421,7 +425,7 @@ const MerchantsMorning = () => {
                 status={inventoryStatus.status}
                 badge={inventoryStatus.badge}
               />
-              {getCardState('inventory').expanded && (
+              {(getCardState('inventory').semiExpanded || getCardState('inventory').expanded) && (
                 <CardContent expanded={getCardState('inventory').expanded}>
                   <InventoryPanel
                     gameState={gameState}
@@ -429,6 +433,8 @@ const MerchantsMorning = () => {
                     setInventoryTab={setInventoryTab}
                     filterInventoryByType={filterInventoryByType}
                     getRarityColor={getRarityColor}
+                    cardState={getCardState('inventory')}
+                    toggleCategory={toggleCategory}
                   />
                 </CardContent>
               )}

--- a/src/features/InventoryPanel.jsx
+++ b/src/features/InventoryPanel.jsx
@@ -10,6 +10,8 @@ const InventoryPanel = ({
   setInventoryTab,
   filterInventoryByType,
   getRarityColor,
+  cardState,
+  toggleCategory,
 }) => {
   const sortedInventory = useMemo(
     () =>
@@ -80,6 +82,12 @@ InventoryPanel.propTypes = {
   setInventoryTab: PropTypes.func.isRequired,
   filterInventoryByType: PropTypes.func.isRequired,
   getRarityColor: PropTypes.func.isRequired,
+  cardState: PropTypes.shape({
+    expanded: PropTypes.bool.isRequired,
+    semiExpanded: PropTypes.bool.isRequired,
+    categoriesOpen: PropTypes.object.isRequired,
+  }).isRequired,
+  toggleCategory: PropTypes.func.isRequired,
 };
 
 export default InventoryPanel;

--- a/src/features/MaterialStallsPanel.jsx
+++ b/src/features/MaterialStallsPanel.jsx
@@ -5,7 +5,7 @@ import TabButton from '../components/TabButton';
 import MaterialStallCard from '../components/MaterialStallCard';
 import useMaterialStalls from '../hooks/useMaterialStalls';
 
-const MaterialStallsPanel = ({ gameState, getRarityColor }) => {
+const MaterialStallsPanel = ({ gameState, getRarityColor, cardState, toggleCategory }) => {
   const { materialsByStall, getStallMaterialCount, getActiveStalls } = useMaterialStalls(gameState.materials);
   const activeStalls = getActiveStalls();
   const [activeStall, setActiveStall] = useState(activeStalls[0] || 'blacksmith');
@@ -96,6 +96,12 @@ MaterialStallsPanel.propTypes = {
     materials: PropTypes.object.isRequired,
   }).isRequired,
   getRarityColor: PropTypes.func.isRequired,
+  cardState: PropTypes.shape({
+    expanded: PropTypes.bool.isRequired,
+    semiExpanded: PropTypes.bool.isRequired,
+    categoriesOpen: PropTypes.object.isRequired,
+  }).isRequired,
+  toggleCategory: PropTypes.func.isRequired,
 };
 
 export default MaterialStallsPanel;

--- a/src/features/Workshop.jsx
+++ b/src/features/Workshop.jsx
@@ -12,6 +12,8 @@ const Workshop = ({
   filterRecipesByType,
   sortRecipesByRarityAndCraftability,
   getRarityColor,
+  cardState,
+  toggleCategory,
 }) => {
   const sortedRecipes = useMemo(
     () => sortRecipesByRarityAndCraftability(filterRecipesByType(craftingTab)),
@@ -97,6 +99,12 @@ Workshop.propTypes = {
   filterRecipesByType: PropTypes.func.isRequired,
   sortRecipesByRarityAndCraftability: PropTypes.func.isRequired,
   getRarityColor: PropTypes.func.isRequired,
+  cardState: PropTypes.shape({
+    expanded: PropTypes.bool.isRequired,
+    semiExpanded: PropTypes.bool.isRequired,
+    categoriesOpen: PropTypes.object.isRequired,
+  }).isRequired,
+  toggleCategory: PropTypes.func.isRequired,
 };
 
 export default Workshop;

--- a/src/types/ui.ts
+++ b/src/types/ui.ts
@@ -6,3 +6,8 @@ export interface CardState {
   categoriesOpen: Record<string, boolean>;
 }
 export type CardStateMap = Record<CardId, CardState>;
+
+export type ThreeStateProps = {
+  cardState: CardState;
+  toggleCategory: (cardId: CardId, category: string) => void;
+};


### PR DESCRIPTION
## Summary
- pass card state and toggleCategory to MaterialStallsPanel, Workshop, and InventoryPanel
- show panel content when either semi-expanded or expanded
- declare ThreeStateProps type for components using card state

## Testing
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_6898c75943fc8320b37568efce89adb6