### PR TITLE
Add three-state rendering for materials, workshop, and inventory panels

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -362,18 +362,16 @@ const MerchantsMorning = () => {
                 status={materialsStatus.status}
                 badge={materialsStatus.badge}
               />
-              {(getCardState('materials').semiExpanded || getCardState('materials').expanded) && (
-                <CardContent expanded={getCardState('materials').expanded}>
-                  <MaterialStallsPanel
-                    gameState={gameState}
-                    getRarityColor={getRarityColor}
-                    cardState={getCardState('materials')}
-                    toggleCategory={toggleCategory}
-                  />
-                </CardContent>
-              )}
-            </Card>
-          </div>
+              <CardContent>
+                <MaterialStallsPanel
+                  gameState={gameState}
+                  getRarityColor={getRarityColor}
+                  cardState={getCardState('materials')}
+                  toggleCategory={toggleCategory}
+                />
+              </CardContent>
+              </Card>
+            </div>
         )}
 
         {!getCardState('workshop').hidden && [PHASES.CRAFTING, PHASES.END_DAY].includes(gameState.phase) && (
@@ -390,24 +388,22 @@ const MerchantsMorning = () => {
                 progress={{ current: craftableRecipes, total: totalRecipes }}
                 subtitle={workshopStatus.subtitle}
               />
-              {(getCardState('workshop').semiExpanded || getCardState('workshop').expanded) && (
-                <CardContent expanded={getCardState('workshop').expanded}>
-                  <Workshop
-                    gameState={gameState}
-                    craftingTab={craftingTab}
-                    setCraftingTab={setCraftingTab}
-                    canCraft={canCraft}
-                    craftItem={craftItem}
-                    filterRecipesByType={filterRecipesByType}
-                    sortRecipesByRarityAndCraftability={sortRecipesByRarityAndCraftability}
-                    getRarityColor={getRarityColor}
-                    cardState={getCardState('workshop')}
-                    toggleCategory={toggleCategory}
-                  />
-                </CardContent>
-              )}
-            </Card>
-          </div>
+              <CardContent>
+                <Workshop
+                  gameState={gameState}
+                  craftingTab={craftingTab}
+                  setCraftingTab={setCraftingTab}
+                  canCraft={canCraft}
+                  craftItem={craftItem}
+                  filterRecipesByType={filterRecipesByType}
+                  sortRecipesByRarityAndCraftability={sortRecipesByRarityAndCraftability}
+                  getRarityColor={getRarityColor}
+                  cardState={getCardState('workshop')}
+                  toggleCategory={toggleCategory}
+                />
+              </CardContent>
+              </Card>
+            </div>
         )}
 
         {!getCardState('inventory').hidden && [PHASES.CRAFTING, PHASES.END_DAY].includes(gameState.phase) && (
@@ -425,21 +421,19 @@ const MerchantsMorning = () => {
                 status={inventoryStatus.status}
                 badge={inventoryStatus.badge}
               />
-              {(getCardState('inventory').semiExpanded || getCardState('inventory').expanded) && (
-                <CardContent expanded={getCardState('inventory').expanded}>
-                  <InventoryPanel
-                    gameState={gameState}
-                    inventoryTab={inventoryTab}
-                    setInventoryTab={setInventoryTab}
-                    filterInventoryByType={filterInventoryByType}
-                    getRarityColor={getRarityColor}
-                    cardState={getCardState('inventory')}
-                    toggleCategory={toggleCategory}
-                  />
-                </CardContent>
-              )}
-            </Card>
-          </div>
+              <CardContent>
+                <InventoryPanel
+                  gameState={gameState}
+                  inventoryTab={inventoryTab}
+                  setInventoryTab={setInventoryTab}
+                  filterInventoryByType={filterInventoryByType}
+                  getRarityColor={getRarityColor}
+                  cardState={getCardState('inventory')}
+                  toggleCategory={toggleCategory}
+                />
+              </CardContent>
+              </Card>
+            </div>
         )}
 
         {!getCardState('customerQueue').hidden && [PHASES.SHOPPING, PHASES.END_DAY].includes(gameState.phase) && (

--- a/src/features/InventoryPanel.jsx
+++ b/src/features/InventoryPanel.jsx
@@ -25,6 +25,54 @@ const InventoryPanel = ({
     [inventoryTab, gameState.inventory, filterInventoryByType]
   );
 
+  const totalItems = useMemo(
+    () => Object.values(gameState.inventory).reduce((s, c) => s + c, 0),
+    [gameState.inventory]
+  );
+
+  if (!cardState.semiExpanded && !cardState.expanded) {
+    return <div className="text-sm text-gray-600">Inventory: {totalItems} items</div>;
+  }
+
+  if (cardState.semiExpanded && !cardState.expanded) {
+    return (
+      <div className="space-y-2">
+        {ITEM_TYPES.map(type => {
+          const items = filterInventoryByType(type);
+          const count = items.reduce((sum, [, c]) => sum + c, 0);
+          const isOpen = cardState.categoriesOpen[type];
+          return (
+            <div key={type}>
+              <button
+                type="button"
+                className="w-full flex justify-between items-center font-medium text-left"
+                onClick={() => toggleCategory('inventory', type)}
+              >
+                <span>
+                  {type.charAt(0).toUpperCase() + type.slice(1)}: {count}
+                </span>
+                <span>{isOpen ? '▲' : '▼'}</span>
+              </button>
+              {isOpen && (
+                <ul className="mt-1 space-y-1">
+                  {items.map(([itemId, c]) => {
+                    const recipe = RECIPES.find(r => r.id === itemId);
+                    return (
+                      <li key={itemId} className="flex justify-between text-sm">
+                        <span>{recipe ? recipe.name : itemId}</span>
+                        <span className="text-gray-600">x{c}</span>
+                      </li>
+                    );
+                  })}
+                </ul>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    );
+  }
+
   return (
     <div>
       <div className="flex gap-1 mb-3 overflow-x-auto pb-1">
@@ -44,35 +92,35 @@ const InventoryPanel = ({
         })}
       </div>
 
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 max-h-80 overflow-y-auto">
-          {sortedInventory.map(([itemId, count]) => {
-            const recipe = RECIPES.find(r => r.id === itemId);
-            return (
-              <InventoryItemCard
-                key={itemId}
-                recipe={recipe}
-                count={count}
-                getRarityColor={getRarityColor}
-              />
-            );
-          })}
-          {sortedInventory.length === 0 && (
-            <div className="col-span-full">
-              <div className="inventory-item-card border-dashed border-gray-300 bg-gray-50 dark:bg-gray-800 flex flex-col items-center justify-center text-center py-8">
-                <div className="text-4xl mb-2">📦</div>
-                <p className="text-sm text-gray-500 italic dark:text-gray-400">
-                  No {inventoryTab}s crafted yet
-                </p>
-                <p className="text-xs text-gray-400 mt-1 dark:text-gray-500">
-                  Visit the workshop to craft items!
-                </p>
-              </div>
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 max-h-80 overflow-y-auto">
+        {sortedInventory.map(([itemId, count]) => {
+          const recipe = RECIPES.find(r => r.id === itemId);
+          return (
+            <InventoryItemCard
+              key={itemId}
+              recipe={recipe}
+              count={count}
+              getRarityColor={getRarityColor}
+            />
+          );
+        })}
+        {sortedInventory.length === 0 && (
+          <div className="col-span-full">
+            <div className="inventory-item-card border-dashed border-gray-300 bg-gray-50 dark:bg-gray-800 flex flex-col items-center justify-center text-center py-8">
+              <div className="text-4xl mb-2">📦</div>
+              <p className="text-sm text-gray-500 italic dark:text-gray-400">
+                No {inventoryTab}s crafted yet
+              </p>
+              <p className="text-xs text-gray-400 mt-1 dark:text-gray-500">
+                Visit the workshop to craft items!
+              </p>
             </div>
-          )}
-        </div>
+          </div>
+        )}
       </div>
-    );
-  };
+    </div>
+  );
+};
 
 InventoryPanel.propTypes = {
   gameState: PropTypes.shape({

--- a/src/features/MaterialStallsPanel.jsx
+++ b/src/features/MaterialStallsPanel.jsx
@@ -1,6 +1,6 @@
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import PropTypes from 'prop-types';
-import { MERCHANT_STALLS } from '../constants';
+import { MERCHANT_STALLS, MATERIALS } from '../constants';
 import TabButton from '../components/TabButton';
 import MaterialStallCard from '../components/MaterialStallCard';
 import useMaterialStalls from '../hooks/useMaterialStalls';
@@ -11,6 +11,77 @@ const MaterialStallsPanel = ({ gameState, getRarityColor, cardState, toggleCateg
   const [activeStall, setActiveStall] = useState(activeStalls[0] || 'blacksmith');
   const [manualSelection, setManualSelection] = useState(false);
 
+  // Collapsed & semi-expanded data
+  const totalMaterials = useMemo(
+    () => Object.values(gameState.materials).reduce((sum, c) => sum + c, 0),
+    [gameState.materials]
+  );
+
+  const materialsByType = useMemo(() => {
+    const groups = {};
+    Object.entries(gameState.materials).forEach(([id, count]) => {
+      if (count <= 0) return;
+      const material = MATERIALS[id];
+      if (!material) return;
+      const type = material.type;
+      if (!groups[type]) groups[type] = [];
+      groups[type].push({ id, ...material, count });
+    });
+    Object.values(groups).forEach(list =>
+      list.sort((a, b) => {
+        const rarityOrder = { rare: 3, uncommon: 2, common: 1 };
+        const rarityDiff = (rarityOrder[b.rarity] || 0) - (rarityOrder[a.rarity] || 0);
+        if (rarityDiff !== 0) return rarityDiff;
+        return a.name.localeCompare(b.name);
+      })
+    );
+    return groups;
+  }, [gameState.materials]);
+
+  // Collapsed view
+  if (!cardState.semiExpanded && !cardState.expanded) {
+    return <div className="text-sm text-gray-600">Materials: {totalMaterials} total</div>;
+  }
+
+  // Semi-expanded view
+  if (cardState.semiExpanded && !cardState.expanded) {
+    return (
+      <div className="space-y-2">
+        {Object.entries(materialsByType).map(([type, mats]) => {
+          const total = mats.reduce((s, m) => s + m.count, 0);
+          const isOpen = cardState.categoriesOpen[type];
+          return (
+            <div key={type}>
+              <button
+                type="button"
+                className="w-full flex justify-between items-center font-medium text-left"
+                onClick={() => toggleCategory('materials', type)}
+              >
+                <span>
+                  {type.charAt(0).toUpperCase() + type.slice(1)}: {total}
+                </span>
+                <span>{isOpen ? '▲' : '▼'}</span>
+              </button>
+              {isOpen && (
+                <div className="grid grid-cols-2 sm:grid-cols-3 gap-2 mt-1">
+                  {mats.map(m => (
+                    <div key={m.id} className="flex items-center gap-1 text-sm">
+                      <span>{m.icon}</span>
+                      <span>
+                        {m.name} x{m.count}
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    );
+  }
+
+  // Expanded view (existing interface)
   // Switch to first available stall if current one becomes empty, unless user manually selected an empty stall
   React.useEffect(() => {
     if (!manualSelection && activeStalls.length > 0 && !activeStalls.includes(activeStall)) {

--- a/src/features/Workshop.jsx
+++ b/src/features/Workshop.jsx
@@ -20,6 +20,59 @@ const Workshop = ({
     [craftingTab, gameState.materials, filterRecipesByType, sortRecipesByRarityAndCraftability]
   );
 
+  const craftableRecipes = useMemo(
+    () => RECIPES.filter(canCraft).length,
+    [gameState.materials, canCraft]
+  );
+  const totalRecipes = RECIPES.length;
+
+  if (!cardState.semiExpanded && !cardState.expanded) {
+    return (
+      <div className="text-sm text-gray-600">
+        Craftable: {craftableRecipes} / Recipes: {totalRecipes}
+      </div>
+    );
+  }
+
+  if (cardState.semiExpanded && !cardState.expanded) {
+    return (
+      <div className="space-y-2">
+        {ITEM_TYPES.map(type => {
+          const allRecipes = filterRecipesByType(type);
+          const craftableCount = allRecipes.filter(canCraft).length;
+          const totalCount = allRecipes.length;
+          const isOpen = cardState.categoriesOpen[type];
+          return (
+            <div key={type}>
+              <button
+                type="button"
+                className="w-full flex justify-between items-center font-medium text-left"
+                onClick={() => toggleCategory('workshop', type)}
+              >
+                <span>
+                  {type.charAt(0).toUpperCase() + type.slice(1)} {craftableCount}/{totalCount}
+                </span>
+                <span>{isOpen ? '▲' : '▼'}</span>
+              </button>
+              {isOpen && (
+                <ul className="mt-1 space-y-1">
+                  {allRecipes.map(recipe => (
+                    <li key={recipe.id} className="flex justify-between text-sm">
+                      <span>{recipe.name}</span>
+                      <span className={canCraft(recipe) ? 'text-green-600' : 'text-red-600'}>
+                        {canCraft(recipe) ? '✓' : '✗'}
+                      </span>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    );
+  }
+
   return (
     <div>
       <div className="flex gap-1 mb-3 overflow-x-auto pb-1">
@@ -53,8 +106,20 @@ const Workshop = ({
           >
             <div className="flex justify-between items-start mb-1">
               <div className="flex-1">
-                <h4 className={`font-bold text-sm sm:text-xs ${canCraft(recipe) ? 'text-black dark:text-white' : 'text-gray-500 dark:text-gray-400'}`}>{recipe.name}</h4>
-                <p className={`text-sm px-1 py-0.5 rounded inline-block mb-1 border ${getRarityColor(recipe.rarity)}`}>
+                <h4
+                  className={`font-bold text-sm sm:text-xs ${
+                    canCraft(recipe)
+                      ? 'text-black dark:text-white'
+                      : 'text-gray-500 dark:text-gray-400'
+                  }`}
+                >
+                  {recipe.name}
+                </h4>
+                <p
+                  className={`text-sm px-1 py-0.5 rounded inline-block mb-1 border ${getRarityColor(
+                    recipe.rarity
+                  )}`}
+                >
                   {recipe.rarity}
                 </p>
               </div>
@@ -108,3 +173,4 @@ Workshop.propTypes = {
 };
 
 export default Workshop;
+


### PR DESCRIPTION
## Summary
- Add collapsed and semi-expanded views to MaterialStallsPanel with category toggles
- Implement three-state rendering in Workshop and Inventory panels with per-type summaries
- Always render card content to surface collapsed summaries

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_6898cec07a9c8320aeb8006c1217c911