### PR TITLE
Add three-state views for materials, workshop, and inventory panels

### DIFF
--- a/src/features/InventoryPanel.jsx
+++ b/src/features/InventoryPanel.jsx
@@ -25,6 +25,54 @@ const InventoryPanel = ({
     [inventoryTab, gameState.inventory, filterInventoryByType]
   );
 
+  const totalItems = useMemo(
+    () => Object.values(gameState.inventory || {}).reduce((s, c) => s + c, 0),
+    [gameState.inventory]
+  );
+
+  if (!cardState.semiExpanded && !cardState.expanded) {
+    return <div>Inventory: {totalItems} items</div>;
+  }
+
+  if (cardState.semiExpanded && !cardState.expanded) {
+    return (
+      <div className="space-y-2">
+        {ITEM_TYPES.map(type => {
+          const items = filterInventoryByType(type);
+          const count = items.reduce((s, [, c]) => s + c, 0);
+          return (
+            <div key={type} className="mb-1">
+              <div
+                className="flex justify-between items-center cursor-pointer"
+                onClick={() => toggleCategory('inventory', type)}
+              >
+                <span className="font-semibold">
+                  {type.charAt(0).toUpperCase() + type.slice(1)}
+                </span>
+                <span className="text-sm">{count}</span>
+              </div>
+              {cardState.categoriesOpen?.[type] && (
+                <div className="pl-4 mt-1 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 max-h-80 overflow-y-auto">
+                  {items.map(([itemId, c]) => {
+                    const recipe = RECIPES.find(r => r.id === itemId);
+                    return (
+                      <InventoryItemCard
+                        key={itemId}
+                        recipe={recipe}
+                        count={c}
+                        getRarityColor={getRarityColor}
+                      />
+                    );
+                  })}
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    );
+  }
+
   return (
     <div>
       <div className="flex gap-1 mb-3 overflow-x-auto pb-1">
@@ -44,35 +92,35 @@ const InventoryPanel = ({
         })}
       </div>
 
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 max-h-80 overflow-y-auto">
-          {sortedInventory.map(([itemId, count]) => {
-            const recipe = RECIPES.find(r => r.id === itemId);
-            return (
-              <InventoryItemCard
-                key={itemId}
-                recipe={recipe}
-                count={count}
-                getRarityColor={getRarityColor}
-              />
-            );
-          })}
-          {sortedInventory.length === 0 && (
-            <div className="col-span-full">
-              <div className="inventory-item-card border-dashed border-gray-300 bg-gray-50 dark:bg-gray-800 flex flex-col items-center justify-center text-center py-8">
-                <div className="text-4xl mb-2">📦</div>
-                <p className="text-sm text-gray-500 italic dark:text-gray-400">
-                  No {inventoryTab}s crafted yet
-                </p>
-                <p className="text-xs text-gray-400 mt-1 dark:text-gray-500">
-                  Visit the workshop to craft items!
-                </p>
-              </div>
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 max-h-80 overflow-y-auto">
+        {sortedInventory.map(([itemId, count]) => {
+          const recipe = RECIPES.find(r => r.id === itemId);
+          return (
+            <InventoryItemCard
+              key={itemId}
+              recipe={recipe}
+              count={count}
+              getRarityColor={getRarityColor}
+            />
+          );
+        })}
+        {sortedInventory.length === 0 && (
+          <div className="col-span-full">
+            <div className="inventory-item-card border-dashed border-gray-300 bg-gray-50 dark:bg-gray-800 flex flex-col items-center justify-center text-center py-8">
+              <div className="text-4xl mb-2">📦</div>
+              <p className="text-sm text-gray-500 italic dark:text-gray-400">
+                No {inventoryTab}s crafted yet
+              </p>
+              <p className="text-xs text-gray-400 mt-1 dark:text-gray-500">
+                Visit the workshop to craft items!
+              </p>
             </div>
-          )}
-        </div>
+          </div>
+        )}
       </div>
-    );
-  };
+    </div>
+  );
+};
 
 InventoryPanel.propTypes = {
   gameState: PropTypes.shape({

--- a/src/features/Workshop.jsx
+++ b/src/features/Workshop.jsx
@@ -20,6 +20,106 @@ const Workshop = ({
     [craftingTab, gameState.materials, filterRecipesByType, sortRecipesByRarityAndCraftability]
   );
 
+  const totalCraftable = useMemo(
+    () => RECIPES.filter(canCraft).length,
+    [gameState.materials]
+  );
+  const totalRecipes = RECIPES.length;
+
+  const renderRecipeCard = recipe => (
+    <div
+      key={recipe.id}
+      className={`border rounded-lg p-2 ${
+        canCraft(recipe)
+          ? 'border-green-300 bg-green-50 dark:bg-green-900'
+          : 'border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-700 opacity-75'
+      }`}
+    >
+      <div className="flex justify-between items-start mb-1">
+        <div className="flex-1">
+          <h4
+            className={`font-bold text-sm sm:text-xs ${
+              canCraft(recipe)
+                ? 'text-black dark:text-white'
+                : 'text-gray-500 dark:text-gray-400'
+            }`}
+          >
+            {recipe.name}
+          </h4>
+          <p
+            className={`text-sm px-1 py-0.5 rounded inline-block mb-1 border ${getRarityColor(
+              recipe.rarity
+            )}`}
+          >
+            {recipe.rarity}
+          </p>
+        </div>
+        <button
+          onClick={() => craftItem(recipe.id)}
+          disabled={!canCraft(recipe)}
+          className={`px-2 py-1 rounded font-bold min-h-[44px] min-w-[44px] text-sm sm:text-xs ${
+            canCraft(recipe)
+              ? 'bg-blue-500 hover:bg-blue-600 text-white'
+              : 'bg-gray-200 text-gray-500 dark:bg-gray-700 dark:text-gray-400 cursor-not-allowed'
+          }`}
+        >
+          {canCraft(recipe) ? '✓ Craft' : '✗ Need Materials'}
+        </button>
+      </div>
+      <div className="flex flex-wrap gap-3 text-sm sm:text-xs text-gray-600 dark:text-gray-300">
+        {Object.entries(recipe.ingredients).map(([mat, count]) => {
+          const have = gameState.materials[mat] || 0;
+          const hasEnough = have >= count;
+          return (
+            <span key={mat} className={`${hasEnough ? 'text-green-600' : 'text-red-600'}`}>
+              {MATERIALS[mat].icon} {count}/{have}
+            </span>
+          );
+        })}
+      </div>
+    </div>
+  );
+
+  if (!cardState.semiExpanded && !cardState.expanded) {
+    return (
+      <div>
+        Craftable: {totalCraftable} / Recipes: {totalRecipes}
+      </div>
+    );
+  }
+
+  if (cardState.semiExpanded && !cardState.expanded) {
+    return (
+      <div className="space-y-2">
+        {ITEM_TYPES.map(type => {
+          const allRecipes = filterRecipesByType(type);
+          const craftableCount = allRecipes.filter(canCraft).length;
+          const totalCount = allRecipes.length;
+          return (
+            <div key={type} className="mb-1">
+              <div
+                className="flex justify-between items-center cursor-pointer"
+                onClick={() => toggleCategory('workshop', type)}
+              >
+                <span className="font-semibold">
+                  {type.charAt(0).toUpperCase() + type.slice(1)}
+                </span>
+                <span className="text-sm">
+                  {craftableCount}/{totalCount}
+                </span>
+              </div>
+              {cardState.categoriesOpen?.[type] && (
+                <div className="pl-4 mt-1 grid grid-cols-1 sm:grid-cols-2 gap-2 max-h-80 overflow-y-auto">
+                  {sortRecipesByRarityAndCraftability(allRecipes).map(renderRecipeCard)}
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    );
+  }
+
   return (
     <div>
       <div className="flex gap-1 mb-3 overflow-x-auto pb-1">
@@ -42,47 +142,7 @@ const Workshop = ({
       </div>
 
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-2 mb-4 max-h-80 overflow-y-auto">
-        {sortedRecipes.map(recipe => (
-          <div
-            key={recipe.id}
-            className={`border rounded-lg p-2 ${
-              canCraft(recipe)
-                ? 'border-green-300 bg-green-50 dark:bg-green-900'
-                : 'border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-700 opacity-75'
-            }`}
-          >
-            <div className="flex justify-between items-start mb-1">
-              <div className="flex-1">
-                <h4 className={`font-bold text-sm sm:text-xs ${canCraft(recipe) ? 'text-black dark:text-white' : 'text-gray-500 dark:text-gray-400'}`}>{recipe.name}</h4>
-                <p className={`text-sm px-1 py-0.5 rounded inline-block mb-1 border ${getRarityColor(recipe.rarity)}`}>
-                  {recipe.rarity}
-                </p>
-              </div>
-              <button
-                onClick={() => craftItem(recipe.id)}
-                disabled={!canCraft(recipe)}
-                className={`px-2 py-1 rounded font-bold min-h-[44px] min-w-[44px] text-sm sm:text-xs ${
-                  canCraft(recipe)
-                    ? 'bg-blue-500 hover:bg-blue-600 text-white'
-                    : 'bg-gray-200 text-gray-500 dark:bg-gray-700 dark:text-gray-400 cursor-not-allowed'
-                }`}
-              >
-                {canCraft(recipe) ? '✓ Craft' : '✗ Need Materials'}
-              </button>
-            </div>
-            <div className="flex flex-wrap gap-3 text-sm sm:text-xs text-gray-600 dark:text-gray-300">
-              {Object.entries(recipe.ingredients).map(([mat, count]) => {
-                const have = gameState.materials[mat] || 0;
-                const hasEnough = have >= count;
-                return (
-                  <span key={mat} className={`${hasEnough ? 'text-green-600' : 'text-red-600'}`}>
-                    {MATERIALS[mat].icon} {count}/{have}
-                  </span>
-                );
-              })}
-            </div>
-          </div>
-        ))}
+        {sortedRecipes.map(renderRecipeCard)}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- Add collapsed and semi-expanded states to MaterialStallsPanel with category toggles
- Add summary and per-type recipe views to Workshop with toggleable lists
- Introduce collapsed and semi-expanded inventory views with per-type item toggles

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6898cec07a9c8320aeb8006c1217c911