### PR TITLE
feat: style inventory cards with rarity gradients

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -432,7 +432,6 @@ const MerchantsMorning = () => {
                     inventoryTab={inventoryTab}
                     setInventoryTab={setInventoryTab}
                     filterInventoryByType={filterInventoryByType}
-                    getRarityColor={getRarityColor}
                     cardState={getCardState('inventory')}
                     toggleCategory={toggleCategory}
                   />

--- a/src/components/InventoryItemCard.jsx
+++ b/src/components/InventoryItemCard.jsx
@@ -2,21 +2,53 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { ITEM_TYPE_ICONS } from '../constants';
 
-const InventoryItemCard = ({ recipe, count, getRarityColor }) => (
-  <div className={`inventory-item-card ${getRarityColor(recipe.rarity)}`}>
-    <div className="item-header">
-      <div className="item-name">{recipe.name}</div>
-      <div className={`rarity-badge rarity-${recipe.rarity}`}>
-        {recipe.rarity}
+function rarityClasses(rarity, dark) {
+  const palettes = dark
+    ? {
+        common: 'from-gray-700 to-gray-600 border-gray-500',
+        uncommon: 'from-green-700 to-green-600 border-green-500',
+        rare: 'from-purple-700 to-purple-600 border-purple-500',
+        legendary: 'from-amber-800 to-amber-600 border-amber-600',
+      }
+    : {
+        common: 'from-gray-100 to-gray-200 border-gray-300',
+        uncommon: 'from-green-100 to-green-200 border-green-300',
+        rare: 'from-purple-100 to-purple-200 border-purple-300',
+        legendary: 'from-amber-50 to-amber-100 border-amber-300',
+      };
+  return `bg-gradient-to-br ${palettes[rarity?.toLowerCase()] || palettes.common}`;
+}
+
+const InventoryItemCard = ({ recipe, count }) => {
+  const isDark =
+    typeof document !== 'undefined' &&
+    document.documentElement.classList.contains('dark');
+  const totalValue = (recipe.sellPrice || 0) * count;
+
+  return (
+    <div
+      className={`inventory-item-card ${rarityClasses(
+        recipe.rarity,
+        isDark
+      )} text-gray-800 dark:text-gray-100 hover:shadow-lg hover:-translate-y-0.5 transition-transform transition-shadow duration-200`}
+    >
+      <div className="item-header">
+        <div className="item-name">{recipe.name}</div>
+        <div className={`rarity-badge rarity-${recipe.rarity}`}>
+          {recipe.rarity}
+        </div>
+      </div>
+      <div className="item-visual">
+        <div className="item-icon">{ITEM_TYPE_ICONS[recipe.type]}</div>
+        <div className="stack-indicator">×{count}</div>
+      </div>
+      <div className="item-value text-xs sm:text-sm flex justify-between">
+        <span>{recipe.sellPrice}g each</span>
+        <span className="font-medium">{totalValue}g</span>
       </div>
     </div>
-    <div className="item-visual">
-      <div className="item-icon">{ITEM_TYPE_ICONS[recipe.type]}</div>
-      <div className="stack-indicator">×{count}</div>
-    </div>
-    <div className="item-value">{recipe.sellPrice}g each</div>
-  </div>
-);
+  );
+};
 
 InventoryItemCard.propTypes = {
   recipe: PropTypes.shape({
@@ -26,7 +58,6 @@ InventoryItemCard.propTypes = {
     sellPrice: PropTypes.number.isRequired,
   }).isRequired,
   count: PropTypes.number.isRequired,
-  getRarityColor: PropTypes.func.isRequired,
 };
 
 export default InventoryItemCard;

--- a/src/features/InventoryPanel.jsx
+++ b/src/features/InventoryPanel.jsx
@@ -9,7 +9,6 @@ const InventoryPanel = ({
   inventoryTab,
   setInventoryTab,
   filterInventoryByType,
-  getRarityColor,
   cardState,
   toggleCategory,
 }) => {
@@ -60,7 +59,6 @@ const InventoryPanel = ({
                         key={itemId}
                         recipe={recipe}
                         count={c}
-                        getRarityColor={getRarityColor}
                       />
                     );
                   })}
@@ -96,12 +94,7 @@ const InventoryPanel = ({
         {sortedInventory.map(([itemId, count]) => {
           const recipe = RECIPES.find(r => r.id === itemId);
           return (
-            <InventoryItemCard
-              key={itemId}
-              recipe={recipe}
-              count={count}
-              getRarityColor={getRarityColor}
-            />
+            <InventoryItemCard key={itemId} recipe={recipe} count={count} />
           );
         })}
         {sortedInventory.length === 0 && (
@@ -129,7 +122,6 @@ InventoryPanel.propTypes = {
   inventoryTab: PropTypes.string.isRequired,
   setInventoryTab: PropTypes.func.isRequired,
   filterInventoryByType: PropTypes.func.isRequired,
-  getRarityColor: PropTypes.func.isRequired,
   cardState: PropTypes.shape({
     expanded: PropTypes.bool.isRequired,
     semiExpanded: PropTypes.bool.isRequired,


### PR DESCRIPTION
## Summary
- add `rarityClasses` helper for light/dark rarity gradients
- show total item value and hover elevation on inventory cards
- drop `getRarityColor` prop from InventoryPanel

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_6898d23704048320aee60b04ff730635