### PR TITLE
Add guards and tests for card panels

### DIFF
--- a/src/features/InventoryPanel.jsx
+++ b/src/features/InventoryPanel.jsx
@@ -34,39 +34,45 @@ const InventoryPanel = ({
   }
 
   if (cardState.semiExpanded && !cardState.expanded) {
+    const categories = ITEM_TYPES.map(type => {
+      const items = filterInventoryByType(type);
+      const count = items.reduce((s, [, c]) => s + c, 0);
+      return { type, items, count };
+    }).filter(c => c.count > 0);
+
+    if (categories.length === 0) {
+      return (
+        <div className="space-y-2">
+          <div className="text-sm italic text-gray-500">No items yet</div>
+        </div>
+      );
+    }
+
     return (
       <div className="space-y-2">
-        {ITEM_TYPES.map(type => {
-          const items = filterInventoryByType(type);
-          const count = items.reduce((s, [, c]) => s + c, 0);
-          return (
-            <div key={type} className="mb-1">
-              <div
-                className="flex justify-between items-center cursor-pointer"
-                onClick={() => toggleCategory('inventory', type)}
-              >
-                <span className="font-semibold">
-                  {type.charAt(0).toUpperCase() + type.slice(1)}
-                </span>
-                <span className="text-sm">{count}</span>
-              </div>
-              {cardState.categoriesOpen?.[type] && (
-                <div className="pl-4 mt-1 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 max-h-80 overflow-y-auto">
-                  {items.map(([itemId, c]) => {
-                    const recipe = RECIPES.find(r => r.id === itemId);
-                    return (
-                      <InventoryItemCard
-                        key={itemId}
-                        recipe={recipe}
-                        count={c}
-                      />
-                    );
-                  })}
-                </div>
-              )}
+        {categories.map(({ type, items, count }) => (
+          <div key={type} className="mb-1">
+            <div
+              className="flex justify-between items-center cursor-pointer"
+              onClick={() => toggleCategory('inventory', type)}
+            >
+              <span className="font-semibold">
+                {type.charAt(0).toUpperCase() + type.slice(1)}
+              </span>
+              <span className="text-sm">{count}</span>
             </div>
-          );
-        })}
+            {cardState.categoriesOpen?.[type] && (
+              <div className="pl-4 mt-1 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 max-h-80 overflow-y-auto">
+                {items.map(([itemId, c]) => {
+                  const recipe = RECIPES.find(r => r.id === itemId);
+                  return (
+                    <InventoryItemCard key={itemId} recipe={recipe} count={c} />
+                  );
+                })}
+              </div>
+            )}
+          </div>
+        ))}
       </div>
     );
   }

--- a/src/features/MaterialStallsPanel.jsx
+++ b/src/features/MaterialStallsPanel.jsx
@@ -50,38 +50,48 @@ const MaterialStallsPanel = ({ gameState, getRarityColor, cardState, toggleCateg
   }
 
   if (cardState.semiExpanded && !cardState.expanded) {
+    const entries = Object.entries(materialsByType).sort((a, b) =>
+      a[0].localeCompare(b[0])
+    );
+
+    if (entries.length === 0) {
+      return (
+        <div className="material-stalls-panel space-y-2">
+          <div className="text-sm italic text-gray-500">No items yet</div>
+        </div>
+      );
+    }
+
     return (
       <div className="material-stalls-panel space-y-2">
-        {Object.entries(materialsByType)
-          .sort((a, b) => a[0].localeCompare(b[0]))
-          .map(([type, mats]) => {
-            const count = mats.reduce((s, m) => s + m.count, 0);
-            return (
-              <div key={type} className="mb-1">
-                <div
-                  className="flex justify-between items-center cursor-pointer"
-                  onClick={() => toggleCategory('materials', type)}
-                >
-                  <span className="font-semibold">
-                    {type.charAt(0).toUpperCase() + type.slice(1)}
-                  </span>
-                  <span className="text-sm">{count}</span>
-                </div>
-                {cardState.categoriesOpen?.[type] && (
-                  <div className="pl-4 mt-1 space-y-1">
-                    {mats.map(mat => (
-                      <div key={mat.id} className="flex justify-between text-sm">
-                        <span>
-                          {mat.icon} {mat.name}
-                        </span>
-                        <span>{mat.count}</span>
-                      </div>
-                    ))}
-                  </div>
-                )}
+        {entries.map(([type, mats]) => {
+          const count = mats.reduce((s, m) => s + m.count, 0);
+          return (
+            <div key={type} className="mb-1">
+              <div
+                className="flex justify-between items-center cursor-pointer"
+                onClick={() => toggleCategory('materials', type)}
+              >
+                <span className="font-semibold">
+                  {type.charAt(0).toUpperCase() + type.slice(1)}
+                </span>
+                <span className="text-sm">{count}</span>
               </div>
-            );
-          })}
+              {cardState.categoriesOpen?.[type] && (
+                <div className="pl-4 mt-1 space-y-1">
+                  {mats.map(mat => (
+                    <div key={mat.id} className="flex justify-between text-sm">
+                      <span>
+                        {mat.icon} {mat.name}
+                      </span>
+                      <span>{mat.count}</span>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          );
+        })}
       </div>
     );
   }

--- a/src/features/Workshop.jsx
+++ b/src/features/Workshop.jsx
@@ -89,33 +89,45 @@ const Workshop = ({
   }
 
   if (cardState.semiExpanded && !cardState.expanded) {
+    const categories = ITEM_TYPES.map(type => {
+      const allRecipes = filterRecipesByType(type);
+      const craftableCount = allRecipes.filter(canCraft).length;
+      const totalCount = allRecipes.length;
+      return { type, allRecipes, craftableCount, totalCount };
+    }).filter(c => c.totalCount > 0);
+
+    if (categories.length === 0) {
+      return (
+        <div className="space-y-2">
+          <div className="text-sm italic text-gray-500">No items yet</div>
+        </div>
+      );
+    }
+
     return (
       <div className="space-y-2">
-        {ITEM_TYPES.map(type => {
-          const allRecipes = filterRecipesByType(type);
-          const craftableCount = allRecipes.filter(canCraft).length;
-          const totalCount = allRecipes.length;
-          return (
-            <div key={type} className="mb-1">
-              <div
-                className="flex justify-between items-center cursor-pointer"
-                onClick={() => toggleCategory('workshop', type)}
-              >
-                <span className="font-semibold">
-                  {type.charAt(0).toUpperCase() + type.slice(1)}
-                </span>
-                <span className="text-sm">
-                  {craftableCount}/{totalCount}
-                </span>
-              </div>
-              {cardState.categoriesOpen?.[type] && (
-                <div className="pl-4 mt-1 grid grid-cols-1 sm:grid-cols-2 gap-2 max-h-80 overflow-y-auto">
-                  {sortRecipesByRarityAndCraftability(allRecipes).map(renderRecipeCard)}
-                </div>
-              )}
+        {categories.map(({ type, allRecipes, craftableCount, totalCount }) => (
+          <div key={type} className="mb-1">
+            <div
+              className="flex justify-between items-center cursor-pointer"
+              onClick={() => toggleCategory('workshop', type)}
+            >
+              <span className="font-semibold">
+                {type.charAt(0).toUpperCase() + type.slice(1)}
+              </span>
+              <span className="text-sm">
+                {craftableCount}/{totalCount}
+              </span>
             </div>
-          );
-        })}
+            {cardState.categoriesOpen?.[type] && (
+              <div className="pl-4 mt-1 grid grid-cols-1 sm:grid-cols-2 gap-2 max-h-80 overflow-y-auto">
+                {sortRecipesByRarityAndCraftability(allRecipes).map(
+                  renderRecipeCard
+                )}
+              </div>
+            )}
+          </div>
+        ))}
       </div>
     );
   }

--- a/src/features/__tests__/InventoryPanel.test.jsx
+++ b/src/features/__tests__/InventoryPanel.test.jsx
@@ -1,0 +1,61 @@
+import { render, screen } from '@testing-library/react';
+import InventoryPanel from '../InventoryPanel';
+import { RECIPES } from '../../constants';
+
+const noop = () => {};
+
+const makeFilter = inventory => type =>
+  Object.entries(inventory).filter(([itemId]) => {
+    const recipe = RECIPES.find(r => r.id === itemId);
+    return recipe?.type === type;
+  });
+
+describe('InventoryPanel', () => {
+  test('collapsed shows total count', () => {
+    const gameState = { inventory: { iron_dagger: 1 } };
+    const filter = makeFilter(gameState.inventory);
+    render(
+      <InventoryPanel
+        gameState={gameState}
+        inventoryTab="weapon"
+        setInventoryTab={noop}
+        filterInventoryByType={filter}
+        cardState={{ expanded: false, semiExpanded: false, categoriesOpen: {} }}
+        toggleCategory={noop}
+      />
+    );
+    expect(screen.getByText(/Inventory:/i)).toBeInTheDocument();
+  });
+
+  test('semi-expanded with no items shows placeholder', () => {
+    const gameState = { inventory: {} };
+    const filter = makeFilter(gameState.inventory);
+    render(
+      <InventoryPanel
+        gameState={gameState}
+        inventoryTab="weapon"
+        setInventoryTab={noop}
+        filterInventoryByType={filter}
+        cardState={{ expanded: false, semiExpanded: true, categoriesOpen: {} }}
+        toggleCategory={noop}
+      />
+    );
+    expect(screen.getByText(/No items yet/i)).toBeInTheDocument();
+  });
+
+  test('expanded renders inventory items', () => {
+    const gameState = { inventory: { iron_dagger: 1 } };
+    const filter = makeFilter(gameState.inventory);
+    render(
+      <InventoryPanel
+        gameState={gameState}
+        inventoryTab="weapon"
+        setInventoryTab={noop}
+        filterInventoryByType={filter}
+        cardState={{ expanded: true, semiExpanded: false, categoriesOpen: {} }}
+        toggleCategory={noop}
+      />
+    );
+    expect(screen.getByText(/Iron Dagger/i)).toBeInTheDocument();
+  });
+});

--- a/src/features/__tests__/MaterialStallsPanel.test.jsx
+++ b/src/features/__tests__/MaterialStallsPanel.test.jsx
@@ -1,0 +1,46 @@
+import { render, screen } from '@testing-library/react';
+import MaterialStallsPanel from '../MaterialStallsPanel';
+
+const noop = () => {};
+const getRarityColor = () => '';
+
+describe('MaterialStallsPanel', () => {
+  test('collapsed renders total materials', () => {
+    const gameState = { materials: { wood: 2 } };
+    render(
+      <MaterialStallsPanel
+        gameState={gameState}
+        getRarityColor={getRarityColor}
+        cardState={{ expanded: false, semiExpanded: false, categoriesOpen: {} }}
+        toggleCategory={noop}
+      />
+    );
+    expect(screen.getByText(/Materials:/i)).toBeInTheDocument();
+  });
+
+  test('semi-expanded with no materials shows placeholder', () => {
+    const gameState = { materials: {} };
+    render(
+      <MaterialStallsPanel
+        gameState={gameState}
+        getRarityColor={getRarityColor}
+        cardState={{ expanded: false, semiExpanded: true, categoriesOpen: {} }}
+        toggleCategory={noop}
+      />
+    );
+    expect(screen.getByText(/No items yet/i)).toBeInTheDocument();
+  });
+
+  test('expanded renders stall content', () => {
+    const gameState = { materials: { iron: 1 } };
+    render(
+      <MaterialStallsPanel
+        gameState={gameState}
+        getRarityColor={getRarityColor}
+        cardState={{ expanded: true, semiExpanded: false, categoriesOpen: {} }}
+        toggleCategory={noop}
+      />
+    );
+    expect(screen.getByText(/Blacksmith/i)).toBeInTheDocument();
+  });
+});

--- a/src/features/__tests__/Workshop.test.jsx
+++ b/src/features/__tests__/Workshop.test.jsx
@@ -1,0 +1,69 @@
+import { render, screen } from '@testing-library/react';
+import Workshop from '../Workshop';
+import { RECIPES } from '../../constants';
+
+const noop = () => {};
+const canCraft = () => true;
+const craftItem = () => {};
+const filterRecipesByType = type => RECIPES.filter(r => r.type === type);
+const sortRecipesByRarityAndCraftability = rs => rs;
+const getRarityColor = () => '';
+
+describe('Workshop', () => {
+  test('collapsed shows craftable counts', () => {
+    const gameState = { materials: {} };
+    render(
+      <Workshop
+        gameState={gameState}
+        craftingTab="weapon"
+        setCraftingTab={noop}
+        canCraft={canCraft}
+        craftItem={craftItem}
+        filterRecipesByType={filterRecipesByType}
+        sortRecipesByRarityAndCraftability={sortRecipesByRarityAndCraftability}
+        getRarityColor={getRarityColor}
+        cardState={{ expanded: false, semiExpanded: false, categoriesOpen: {} }}
+        toggleCategory={noop}
+      />
+    );
+    expect(screen.getByText(/Craftable:/i)).toBeInTheDocument();
+  });
+
+  test('semi-expanded shows categories', () => {
+    const gameState = { materials: {} };
+    render(
+      <Workshop
+        gameState={gameState}
+        craftingTab="weapon"
+        setCraftingTab={noop}
+        canCraft={canCraft}
+        craftItem={craftItem}
+        filterRecipesByType={filterRecipesByType}
+        sortRecipesByRarityAndCraftability={sortRecipesByRarityAndCraftability}
+        getRarityColor={getRarityColor}
+        cardState={{ expanded: false, semiExpanded: true, categoriesOpen: {} }}
+        toggleCategory={noop}
+      />
+    );
+    expect(screen.getByText(/Weapon/i)).toBeInTheDocument();
+  });
+
+  test('expanded renders recipe list', () => {
+    const gameState = { materials: {} };
+    render(
+      <Workshop
+        gameState={gameState}
+        craftingTab="weapon"
+        setCraftingTab={noop}
+        canCraft={canCraft}
+        craftItem={craftItem}
+        filterRecipesByType={filterRecipesByType}
+        sortRecipesByRarityAndCraftability={sortRecipesByRarityAndCraftability}
+        getRarityColor={getRarityColor}
+        cardState={{ expanded: true, semiExpanded: false, categoriesOpen: {} }}
+        toggleCategory={noop}
+      />
+    );
+    expect(screen.getByText(/Iron Dagger/i)).toBeInTheDocument();
+  });
+});

--- a/src/hooks/__tests__/useCardIntelligence.test.js
+++ b/src/hooks/__tests__/useCardIntelligence.test.js
@@ -1,0 +1,22 @@
+import { renderHook, act } from '@testing-library/react';
+import useCardIntelligence from '../useCardIntelligence';
+
+describe('useCardIntelligence', () => {
+  test('category state persists within phase and resets on phase change', () => {
+    const initial = { phase: 'morning', materials: {}, inventory: {}, craftableCount: 0 };
+    const { result, rerender } = renderHook(({ gs }) => useCardIntelligence(gs), {
+      initialProps: { gs: initial },
+    });
+
+    act(() => {
+      result.current.toggleCategory('materials', 'wood');
+    });
+    expect(result.current.getCardState('materials').categoriesOpen.wood).toBe(true);
+
+    rerender({ gs: { ...initial, materials: { wood: 2 } } });
+    expect(result.current.getCardState('materials').categoriesOpen.wood).toBe(true);
+
+    rerender({ gs: { ...initial, phase: 'crafting' } });
+    expect(result.current.getCardState('materials').categoriesOpen.wood).toBeUndefined();
+  });
+});

--- a/src/hooks/useCardIntelligence.js
+++ b/src/hooks/useCardIntelligence.js
@@ -1,11 +1,17 @@
 import { useCallback, useEffect, useState } from 'react';
 import { getDefaultCardStatesForPhase } from '../utils/cardContext';
 import { BOX_TYPES } from '../constants';
+
 const applyPhaseDefaults = (prev, phase) => {
   const defaults = getDefaultCardStatesForPhase(phase);
   const merged = {};
-  Object.keys(defaults).forEach((key) => {
-    merged[key] = { ...(prev[key] || {}), ...defaults[key] };
+  Object.keys(defaults).forEach(key => {
+    merged[key] = {
+      ...(prev[key] || {}),
+      ...defaults[key],
+      categoriesOpen: {},
+      expandedCategories: [],
+    };
   });
   return merged;
 };
@@ -42,30 +48,21 @@ const useCardIntelligence = (gameState) => {
   );
 
   const toggleCategory = useCallback((cardId, category) => {
-    setCardStates((prev) => {
-      const current =
+    setCardStates(prev => {
+      const card =
         prev[cardId] || {
           expanded: false,
           semiExpanded: false,
           hidden: false,
-          expandedCategories: [],
           categoriesOpen: {},
+          expandedCategories: [],
         };
-      const setCat = new Set(current.expandedCategories || []);
-      let isOpen;
-      if (setCat.has(category)) {
-        setCat.delete(category);
-        isOpen = false;
-      } else {
-        setCat.add(category);
-        isOpen = true;
-      }
+      const open = card.categoriesOpen?.[category] ?? false;
       return {
         ...prev,
         [cardId]: {
-          ...current,
-          expandedCategories: Array.from(setCat),
-          categoriesOpen: { ...(current.categoriesOpen || {}), [category]: isOpen },
+          ...card,
+          categoriesOpen: { ...card.categoriesOpen, [category]: !open },
         },
       };
     });


### PR DESCRIPTION
## Summary
- handle empty category lists with a friendly placeholder in Materials, Workshop, and Inventory panels
- reset card category state on phase changes and guard category toggling
- add tests for collapsed, semi-expanded, and expanded states plus card state persistence

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_6898d58b2f008320a4525457b8ac7d01