### PR TITLE
Polish interface with themed header and navigation

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,6 +3,7 @@ import { PHASES } from './constants';
 import PrepTabs from './features/PrepTabs';
 import ShopInterface from './features/ShopInterface';
 import BottomNavigation from './components/BottomNavigation';
+import GameHeader from './components/GameHeader';
 import EventLog from './components/EventLog';
 import Notifications from './components/Notifications';
 import UpdateToast from './components/UpdateToast';
@@ -79,31 +80,34 @@ const MerchantsMorning = () => {
   };
 
   return (
-    <div className="pb-16 space-y-4">
-      {currentPhase === 'prep' ? (
-        <PrepTabs
-          currentTab={currentPrepTab}
-          onTabChange={setCurrentPrepTab}
-          gameState={gameState}
-          openBox={openBox}
-          canCraft={canCraft}
-          craftItem={craftItem}
-          filterRecipesByType={filterRecipesByType}
-          sortRecipesByRarityAndCraftability={sortRecipesByRarityAndCraftability}
-          filterInventoryByType={filterInventoryByType}
-          onReadyToSell={() => handlePhaseChange('shop')}
-        />
-      ) : (
-        <ShopInterface
-          gameState={gameState}
-          selectedCustomer={selectedCustomer}
-          setSelectedCustomer={setSelectedCustomer}
-          filterInventoryByType={filterInventoryByType}
-          sortByMatchQualityAndRarity={sortByMatchQualityAndRarity}
-          serveCustomer={serveCustomer}
-          getSaleInfo={getSaleInfo}
-        />
-      )}
+    <div className="min-h-screen bg-gradient-to-b from-amber-50 to-orange-200 flex flex-col">
+      <GameHeader currentPhase={currentPhase} day={gameState.day} gold={gameState.gold} />
+      <main className="flex-1 pb-24 px-4 space-y-4">
+        {currentPhase === 'prep' ? (
+          <PrepTabs
+            currentTab={currentPrepTab}
+            onTabChange={setCurrentPrepTab}
+            gameState={gameState}
+            openBox={openBox}
+            canCraft={canCraft}
+            craftItem={craftItem}
+            filterRecipesByType={filterRecipesByType}
+            sortRecipesByRarityAndCraftability={sortRecipesByRarityAndCraftability}
+            filterInventoryByType={filterInventoryByType}
+            onReadyToSell={() => handlePhaseChange('shop')}
+          />
+        ) : (
+          <ShopInterface
+            gameState={gameState}
+            selectedCustomer={selectedCustomer}
+            setSelectedCustomer={setSelectedCustomer}
+            filterInventoryByType={filterInventoryByType}
+            sortByMatchQualityAndRarity={sortByMatchQualityAndRarity}
+            serveCustomer={serveCustomer}
+            getSaleInfo={getSaleInfo}
+          />
+        )}
+      </main>
       <BottomNavigation
         currentPhase={currentPhase}
         onPhaseChange={handlePhaseChange}

--- a/src/components/BottomNavigation.jsx
+++ b/src/components/BottomNavigation.jsx
@@ -3,20 +3,22 @@ import PropTypes from 'prop-types';
 
 const BottomNavigation = ({ currentPhase, onPhaseChange, customerCount = 0 }) => {
   return (
-    <nav className="fixed bottom-0 left-0 right-0 bg-white border-t border-gray-200 flex justify-around z-10 dark:bg-gray-800 dark:border-gray-700">
+    <nav className="fixed bottom-0 left-0 right-0 bg-white border-t border-gray-200 grid grid-cols-2 shadow-lg z-10">
       <button
-        className={`flex-1 text-center py-2 ${currentPhase === 'prep' ? 'text-blue-600 font-semibold' : 'text-gray-600 dark:text-gray-300'}`}
+        className={`flex flex-col items-center gap-0.5 p-3 transition-colors ${currentPhase === 'prep' ? 'bg-gradient-to-br from-blue-500 to-blue-700 text-white' : 'text-gray-700 hover:bg-gray-50'}`}
         onClick={() => onPhaseChange('prep')}
       >
-        <div className="text-lg">🛠️</div>
-        <div className="text-xs">Prep Work</div>
+        <div className="text-xl">🛠️</div>
+        <div className="text-sm font-medium">Prep Work</div>
+        <div className="text-xs opacity-80">Buy • Craft • Organize</div>
       </button>
       <button
-        className={`flex-1 text-center py-2 ${currentPhase === 'shop' ? 'text-blue-600 font-semibold' : 'text-gray-600 dark:text-gray-300'}`}
+        className={`flex flex-col items-center gap-0.5 p-3 transition-colors ${currentPhase === 'shop' ? 'bg-gradient-to-br from-blue-500 to-blue-700 text-white' : 'text-gray-700 hover:bg-gray-50'}`}
         onClick={() => onPhaseChange('shop')}
       >
-        <div className="text-lg">🛒</div>
-        <div className="text-xs">{customerCount} customers</div>
+        <div className="text-xl">🛒</div>
+        <div className="text-sm font-medium">Shop</div>
+        <div className="text-xs opacity-80">{customerCount} customers waiting</div>
       </button>
     </nav>
   );

--- a/src/components/GameHeader.jsx
+++ b/src/components/GameHeader.jsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const phaseGradient = phase => (
+  phase === 'shop' ? 'from-green-500 to-green-700' : 'from-blue-500 to-blue-700'
+);
+
+const GameHeader = ({ currentPhase, day, gold }) => {
+  return (
+    <header className="sticky top-0 z-50 bg-white shadow">
+      <div className="max-w-md mx-auto px-4 py-3 flex items-center justify-between">
+        <h1 className="text-sm font-bold text-amber-800">🏰 Merchant's Morning</h1>
+        <div className={`text-white text-xs font-medium px-3 py-1 rounded-full bg-gradient-to-br ${phaseGradient(currentPhase)}`}>
+          {currentPhase === 'shop' ? `🛒 Shop - Day ${day}` : `🛠️ Prep - Day ${day}`}
+        </div>
+        <div className="flex items-center gap-1 px-3 py-1 rounded-full text-white font-semibold bg-gradient-to-br from-yellow-500 to-yellow-600">
+          <span>💰</span>
+          <span>{gold}</span>
+        </div>
+      </div>
+    </header>
+  );
+};
+
+GameHeader.propTypes = {
+  currentPhase: PropTypes.oneOf(['prep', 'shop']).isRequired,
+  day: PropTypes.number.isRequired,
+  gold: PropTypes.number.isRequired,
+};
+
+export default GameHeader;

--- a/src/features/PrepTabs.jsx
+++ b/src/features/PrepTabs.jsx
@@ -18,7 +18,7 @@ const PrepTabs = ({
   onReadyToSell,
 }) => {
   const renderMarket = () => (
-    <div className="space-y-4">
+    <div className="space-y-4 bg-white rounded-xl shadow p-4">
       <div className="space-y-2">
         {gameState.marketReports.map(r => (
           <div key={r.id} className="p-3 bg-blue-50 border border-blue-200 rounded">
@@ -47,21 +47,29 @@ const PrepTabs = ({
     </div>
   );
 
-  const renderMaterials = () => <MaterialStallsPanel gameState={gameState} />;
+  const renderMaterials = () => (
+    <div className="bg-white rounded-xl shadow p-4">
+      <MaterialStallsPanel gameState={gameState} />
+    </div>
+  );
 
   const renderWorkshop = () => (
-    <Workshop
-      gameState={gameState}
-      canCraft={canCraft}
-      craftItem={craftItem}
-      filterRecipesByType={filterRecipesByType}
-      sortRecipesByRarityAndCraftability={sortRecipesByRarityAndCraftability}
-    />
+    <div className="bg-white rounded-xl shadow p-4">
+      <Workshop
+        gameState={gameState}
+        canCraft={canCraft}
+        craftItem={craftItem}
+        filterRecipesByType={filterRecipesByType}
+        sortRecipesByRarityAndCraftability={sortRecipesByRarityAndCraftability}
+      />
+    </div>
   );
 
   const renderItems = () => (
     <div className="space-y-4">
-      <InventoryPanel gameState={gameState} filterInventoryByType={filterInventoryByType} />
+      <div className="bg-white rounded-xl shadow p-4">
+        <InventoryPanel gameState={gameState} filterInventoryByType={filterInventoryByType} />
+      </div>
       <div className="text-center">
         <button
           onClick={onReadyToSell}
@@ -97,19 +105,19 @@ const PrepTabs = ({
 
   return (
     <div>
-      <div className="flex prep-tabs border-b mb-4">
+      <div className="flex gap-2 overflow-x-auto pb-2 mb-4">
         {tabs.map(tab => (
           <button
             key={tab.id}
             onClick={() => onTabChange(tab.id)}
-            className={`flex-1 py-2 text-center ${currentTab === tab.id ? 'border-b-2 border-blue-500 font-semibold' : 'text-gray-500'}`}
+            className={`min-w-[80px] px-3 py-2 rounded-lg border-2 flex flex-col items-center text-xs transition-colors ${currentTab === tab.id ? 'bg-gradient-to-br from-blue-500 to-blue-700 text-white border-blue-500' : 'bg-white border-gray-200 text-gray-700 hover:bg-gray-50'}`}
           >
-            <div className="text-lg">{tab.icon}</div>
-            <div className="text-xs">{tab.label}</div>
+            <div className="text-lg mb-1">{tab.icon}</div>
+            <div className="font-medium">{tab.label}</div>
           </button>
         ))}
       </div>
-      <div className="p-4">{renderContent()}</div>
+      {renderContent()}
     </div>
   );
 };

--- a/src/hooks/__tests__/useCardIntelligence.test.js
+++ b/src/hooks/__tests__/useCardIntelligence.test.js
@@ -11,12 +11,12 @@ describe('useCardIntelligence', () => {
     act(() => {
       result.current.toggleCategory('materials', 'wood');
     });
-    expect(result.current.getCardState('materials').categoriesOpen.wood).toBe(true);
+    expect(result.current.getCardState('materials').expandedCategories).toContain('wood');
 
     rerender({ gs: { ...initial, materials: { wood: 2 } } });
-    expect(result.current.getCardState('materials').categoriesOpen.wood).toBe(true);
+    expect(result.current.getCardState('materials').expandedCategories).toContain('wood');
 
     rerender({ gs: { ...initial, phase: 'crafting' } });
-    expect(result.current.getCardState('materials').categoriesOpen.wood).toBeUndefined();
+    expect(result.current.getCardState('materials').expandedCategories).not.toContain('wood');
   });
 });


### PR DESCRIPTION
## Summary
- add reusable GameHeader with phase badge and gold counter
- restyle bottom navigation and prep tabs to match mobile mockup
- adjust layout and tests for updated category state

## Testing
- `npm test --silent -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_68992936bb0c8320a3a19d83526a5871