### PR TITLE
feat: polish UI with header and navigation

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useRef } from 'react';
 import { PHASES } from './constants';
 import PrepTabs from './features/PrepTabs';
 import ShopInterface from './features/ShopInterface';
+import Header from './components/Header';
 import BottomNavigation from './components/BottomNavigation';
 import EventLog from './components/EventLog';
 import Notifications from './components/Notifications';
@@ -79,31 +80,34 @@ const MerchantsMorning = () => {
   };
 
   return (
-    <div className="pb-16 space-y-4">
-      {currentPhase === 'prep' ? (
-        <PrepTabs
-          currentTab={currentPrepTab}
-          onTabChange={setCurrentPrepTab}
-          gameState={gameState}
-          openBox={openBox}
-          canCraft={canCraft}
-          craftItem={craftItem}
-          filterRecipesByType={filterRecipesByType}
-          sortRecipesByRarityAndCraftability={sortRecipesByRarityAndCraftability}
-          filterInventoryByType={filterInventoryByType}
-          onReadyToSell={() => handlePhaseChange('shop')}
-        />
-      ) : (
-        <ShopInterface
-          gameState={gameState}
-          selectedCustomer={selectedCustomer}
-          setSelectedCustomer={setSelectedCustomer}
-          filterInventoryByType={filterInventoryByType}
-          sortByMatchQualityAndRarity={sortByMatchQualityAndRarity}
-          serveCustomer={serveCustomer}
-          getSaleInfo={getSaleInfo}
-        />
-      )}
+    <div className="min-h-screen flex flex-col bg-gradient-to-b from-amber-50 to-orange-200">
+      <Header currentPhase={currentPhase} day={gameState.day} gold={gameState.gold} />
+      <main className="flex-1 max-w-md w-full mx-auto p-4 pb-24">
+        {currentPhase === 'prep' ? (
+          <PrepTabs
+            currentTab={currentPrepTab}
+            onTabChange={setCurrentPrepTab}
+            gameState={gameState}
+            openBox={openBox}
+            canCraft={canCraft}
+            craftItem={craftItem}
+            filterRecipesByType={filterRecipesByType}
+            sortRecipesByRarityAndCraftability={sortRecipesByRarityAndCraftability}
+            filterInventoryByType={filterInventoryByType}
+            onReadyToSell={() => handlePhaseChange('shop')}
+          />
+        ) : (
+          <ShopInterface
+            gameState={gameState}
+            selectedCustomer={selectedCustomer}
+            setSelectedCustomer={setSelectedCustomer}
+            filterInventoryByType={filterInventoryByType}
+            sortByMatchQualityAndRarity={sortByMatchQualityAndRarity}
+            serveCustomer={serveCustomer}
+            getSaleInfo={getSaleInfo}
+          />
+        )}
+      </main>
       <BottomNavigation
         currentPhase={currentPhase}
         onPhaseChange={handlePhaseChange}

--- a/src/components/BottomNavigation.jsx
+++ b/src/components/BottomNavigation.jsx
@@ -3,20 +3,24 @@ import PropTypes from 'prop-types';
 
 const BottomNavigation = ({ currentPhase, onPhaseChange, customerCount = 0 }) => {
   return (
-    <nav className="fixed bottom-0 left-0 right-0 bg-white border-t border-gray-200 flex justify-around z-10 dark:bg-gray-800 dark:border-gray-700">
+    <nav className="fixed bottom-0 left-0 right-0 bg-white border-t border-gray-200 grid grid-cols-2 shadow-md z-10">
       <button
-        className={`flex-1 text-center py-2 ${currentPhase === 'prep' ? 'text-blue-600 font-semibold' : 'text-gray-600 dark:text-gray-300'}`}
+        className={`flex flex-col items-center gap-1 py-2 ${currentPhase === 'prep' ? 'bg-gradient-to-tr from-blue-500 to-blue-700 text-white' : 'text-gray-700 hover:bg-gray-100'}`}
         onClick={() => onPhaseChange('prep')}
       >
-        <div className="text-lg">🛠️</div>
-        <div className="text-xs">Prep Work</div>
+        <div className="text-xl">🛠️</div>
+        <div className="text-sm font-medium">Prep Work</div>
+        <div className="text-xs opacity-80">Buy • Craft • Organize</div>
       </button>
       <button
-        className={`flex-1 text-center py-2 ${currentPhase === 'shop' ? 'text-blue-600 font-semibold' : 'text-gray-600 dark:text-gray-300'}`}
+        className={`flex flex-col items-center gap-1 py-2 ${currentPhase === 'shop' ? 'bg-gradient-to-tr from-blue-500 to-blue-700 text-white' : 'text-gray-700 hover:bg-gray-100'}`}
         onClick={() => onPhaseChange('shop')}
       >
-        <div className="text-lg">🛒</div>
-        <div className="text-xs">{customerCount} customers</div>
+        <div className="text-xl">🛒</div>
+        <div className="text-sm font-medium">Shop</div>
+        <div className="text-xs opacity-80">
+          {customerCount} {customerCount === 1 ? 'customer' : 'customers'} waiting
+        </div>
       </button>
     </nav>
   );

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const Header = ({ currentPhase, day, gold }) => {
+  const phaseLabel = currentPhase === 'prep' ? 'Prep' : 'Shop';
+  const phaseIcon = currentPhase === 'prep' ? '🛠️' : '🛒';
+
+  return (
+    <header className="bg-white p-4 shadow-md sticky top-0 z-50">
+      <div className="flex justify-between items-center">
+        <h1 className="text-base font-bold text-amber-700">
+          🏰 Merchant's Morning
+        </h1>
+        <div className="flex items-center gap-2">
+          <span className="bg-gradient-to-tr from-blue-500 to-blue-700 text-white px-3 py-1 rounded-full text-xs font-medium">
+            {phaseIcon} {phaseLabel} - Day {day}
+          </span>
+          <div className="bg-gradient-to-tr from-amber-400 to-amber-600 text-white px-3 py-1 rounded-full font-bold flex items-center gap-1 text-sm">
+            <span>💰</span>
+            <span>{gold}</span>
+          </div>
+        </div>
+      </div>
+    </header>
+  );
+};
+
+Header.propTypes = {
+  currentPhase: PropTypes.oneOf(['prep', 'shop']).isRequired,
+  day: PropTypes.number.isRequired,
+  gold: PropTypes.number.isRequired,
+};
+
+export default Header;

--- a/src/features/PrepTabs.jsx
+++ b/src/features/PrepTabs.jsx
@@ -27,7 +27,7 @@ const PrepTabs = ({
         ))}
       </div>
       <div className="grid gap-3 supply-boxes">
-        {['bronze','silver','gold','platinum'].map(key => {
+        {['bronze', 'silver', 'gold', 'platinum'].map(key => {
           const box = BOX_TYPES[key];
           const affordable = gameState.gold >= box.cost;
           return (
@@ -35,11 +35,11 @@ const PrepTabs = ({
               key={key}
               onClick={() => openBox(key)}
               disabled={!affordable}
-              className={`border rounded p-3 flex flex-col items-center justify-center text-sm ${affordable ? 'bg-white' : 'bg-gray-100 text-gray-400 cursor-not-allowed'}`}
+              className={`rounded-xl p-4 text-center transition transform active:scale-95 border-2 flex flex-col items-center text-sm ${affordable ? 'bg-gradient-to-tr from-amber-50 to-amber-200 border-amber-500' : 'bg-gray-100 border-gray-300 text-gray-400 cursor-not-allowed'}`}
             >
-              <span className="font-semibold">{box.name}</span>
-              <span className="text-xs">{box.cost}g</span>
-              <span className="text-xs">{box.materialCount[0]}-{box.materialCount[1]} mats</span>
+              <span className="font-bold">{box.name}</span>
+              <span className="text-xs text-amber-700 mb-1">{box.cost}g</span>
+              <span className="text-[0.65rem] opacity-80">{box.materialCount[0]}-{box.materialCount[1]} mats</span>
             </button>
           );
         })}
@@ -97,19 +97,19 @@ const PrepTabs = ({
 
   return (
     <div>
-      <div className="flex prep-tabs border-b mb-4">
+      <div className="flex gap-2 prep-tabs mb-4 overflow-x-auto pb-2">
         {tabs.map(tab => (
           <button
             key={tab.id}
             onClick={() => onTabChange(tab.id)}
-            className={`flex-1 py-2 text-center ${currentTab === tab.id ? 'border-b-2 border-blue-500 font-semibold' : 'text-gray-500'}`}
+            className={`flex flex-col items-center flex-none px-3 py-2 rounded-lg border-2 min-w-[80px] transition-colors ${currentTab === tab.id ? 'bg-gradient-to-tr from-blue-500 to-blue-700 text-white border-blue-500' : 'bg-white text-gray-700 border-gray-200 hover:bg-gray-50'}`}
           >
-            <div className="text-lg">{tab.icon}</div>
-            <div className="text-xs">{tab.label}</div>
+            <div className="text-lg mb-0.5">{tab.icon}</div>
+            <div className="text-xs font-medium">{tab.label}</div>
           </button>
         ))}
       </div>
-      <div className="p-4">{renderContent()}</div>
+      <div className="space-y-4">{renderContent()}</div>
     </div>
   );
 };

--- a/src/hooks/__tests__/useCardIntelligence.test.js
+++ b/src/hooks/__tests__/useCardIntelligence.test.js
@@ -11,12 +11,12 @@ describe('useCardIntelligence', () => {
     act(() => {
       result.current.toggleCategory('materials', 'wood');
     });
-    expect(result.current.getCardState('materials').categoriesOpen.wood).toBe(true);
+    expect(result.current.getCardState('materials').expandedCategories).toContain('wood');
 
     rerender({ gs: { ...initial, materials: { wood: 2 } } });
-    expect(result.current.getCardState('materials').categoriesOpen.wood).toBe(true);
+    expect(result.current.getCardState('materials').expandedCategories).toContain('wood');
 
     rerender({ gs: { ...initial, phase: 'crafting' } });
-    expect(result.current.getCardState('materials').categoriesOpen.wood).toBeUndefined();
+    expect(result.current.getCardState('materials').expandedCategories).not.toContain('wood');
   });
 });


### PR DESCRIPTION
## Summary
- Add sticky header showing current phase and gold
- Restyle prep tabs and supply boxes
- Revamp bottom navigation with sublabels and active gradients
- Adjust card intelligence tests for expandedCategories

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68992936bb0c8320a3a19d83526a5871