### PR TITLE
Add tip bonuses for exceptional sales

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -8,7 +8,7 @@ A fantasy shopkeeping Progressive Web App where you craft items from materials a
 - **Progressive Difficulty**: Customers want more valuable items as days progress
 - **Smart Crafting System**: Tabbed interface with rarity-based sorting
 - **Expanded Crafting**: Weapons, armor, trinkets, potions, and tools
-- **Strategic Selling**: Match customer requests and earn bonuses for upgrades
+- **Strategic Selling**: Match customer requests, earn bonuses for upgrades, and even collect tips
 - **PWA Ready**: Install on mobile/desktop, works offline
 
 ## 🚀 Quick Setup
@@ -55,7 +55,7 @@ A fantasy shopkeeping Progressive Web App where you craft items from materials a
 ### Shopping Phase
 - Select customers from horizontal tabs
 - Auto-switches to relevant product category
-- Perfect matches = full payment
+- Perfect matches = full payment (plus a generous tip!)
 - Wrong item types cannot be sold
 
 ### End of Day

--- a/src/hooks/__tests__/gameLogic.test.js
+++ b/src/hooks/__tests__/gameLogic.test.js
@@ -109,9 +109,10 @@ describe('core game logic', () => {
     serveCustomer('c1', 'iron_dagger');
 
     expect(state.inventory.iron_dagger).toBe(0);
-    expect(state.gold).toBe(11);
+    expect(state.gold).toBe(12);
     expect(state.customers[0].satisfied).toBe(true);
-    expect(state.customers[0].payment).toBe(11);
+    expect(state.customers[0].payment).toBe(12);
+    expect(state.customers[0].tip).toBe(1);
   });
 
   test('serveCustomer rewards higher rarity upgrades', () => {
@@ -141,8 +142,9 @@ describe('core game logic', () => {
 
     serveCustomer('c1', 'iron_sword');
 
-    expect(state.gold).toBe(135);
-    expect(state.customers[0].payment).toBe(135);
+    expect(state.gold).toBe(142);
+    expect(state.customers[0].payment).toBe(142);
+    expect(state.customers[0].tip).toBe(7);
     expect(state.customers[0].satisfaction).toBe('delighted upgrade');
   });
 

--- a/src/hooks/useCustomers.js
+++ b/src/hooks/useCustomers.js
@@ -205,6 +205,15 @@ const useCustomers = (gameState, setGameState, addEvent, addNotification, setSel
       satisfaction = action === 'barter' ? 'barter trade' : 'accepted lower offer';
     }
 
+    let tip = 0;
+    if (['perfect match', 'perfect style match', 'delighted upgrade'].includes(satisfaction)) {
+      tip = Math.max(1, Math.round(finalPayment * 0.05));
+      if (action === 'sell' && finalPayment + tip > customer.maxBudget) {
+        tip = Math.max(0, customer.maxBudget - finalPayment);
+      }
+      finalPayment += tip;
+    }
+
     const newInventory = { ...gameState.inventory };
     newInventory[itemId] -= 1;
 
@@ -218,7 +227,7 @@ const useCustomers = (gameState, setGameState, addEvent, addNotification, setSel
 
     const newCustomers = gameState.customers.map(c =>
       c.id === customerId
-        ? { ...c, satisfied: true, payment: finalPayment, satisfaction }
+        ? { ...c, satisfied: true, payment: finalPayment, satisfaction, tip }
         : c
     );
 
@@ -243,12 +252,13 @@ const useCustomers = (gameState, setGameState, addEvent, addNotification, setSel
             .map(m => MATERIALS[m.id].name)
             .join(', ')})`
         : '';
+    const tipText = tip ? ` including ${tip} gold tip` : '';
     addEvent(
-      `Sold ${recipe.name} to ${customer.name} for ${finalPayment} gold${matText} ${matchText}`,
+      `Sold ${recipe.name} to ${customer.name} for ${finalPayment} gold${tipText}${matText} ${matchText}`,
       'success'
     );
     addNotification(
-      `💰 Sold ${recipe.name} for ${finalPayment} gold${action === 'barter' ? ' + materials' : ''}!`,
+      `💰 Sold ${recipe.name} for ${finalPayment} gold${tip ? ' including tip' : ''}${action === 'barter' ? ' + materials' : ''}!`,
       'success'
     );
     setSelectedCustomer(null);


### PR DESCRIPTION
## Summary
- add tipping mechanic for perfect or upgraded sales
- track tip amounts on customers and surface in notifications
- document and test tip-based sales bonuses

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689a134232bc8320ab7b98817e940b33