### PR TITLE
Add in-app debug console for testing

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -12,15 +12,17 @@ import useGameState from './hooks/useGameState';
 import useCrafting from './hooks/useCrafting';
 import useCustomers from './hooks/useCustomers';
 import generateId from './utils/id';
+import DebugConsole from './components/DebugConsole';
 
 const MerchantsMorning = () => {
-  const [gameState, setGameState] = useGameState();
+  const [gameState, setGameState, resetGame] = useGameState();
   const [gamePhase, setGamePhase] = useState('prep');
   const [currentPrepTab, setCurrentPrepTab] = useState('market');
   const [selectedCustomer, setSelectedCustomer] = useState(null);
   const [eventLog, setEventLog] = useState([]);
   const [notifications, setNotifications] = useState([]);
   const notificationTimers = useRef([]);
+  const [showDebug, setShowDebug] = useState(false);
 
   const addEvent = (message, type = 'info') => {
     const event = {
@@ -146,6 +148,26 @@ const MerchantsMorning = () => {
       <Notifications notifications={notifications} />
       <EventLog events={eventLog} />
       <UpdateToast />
+
+      {process.env.NODE_ENV !== 'production' && (
+        <>
+          <button
+            className="fixed bottom-4 right-4 bg-gray-700 text-white px-3 py-1 rounded z-50"
+            onClick={() => setShowDebug(prev => !prev)}
+          >
+            {showDebug ? 'Close Debug' : 'Debug'}
+          </button>
+          {showDebug && (
+            <DebugConsole
+              gameState={gameState}
+              setGameState={setGameState}
+              resetGame={resetGame}
+              openShop={openShop}
+              serveCustomer={serveCustomer}
+            />
+          )}
+        </>
+      )}
     </div>
   );
 };

--- a/src/components/DebugConsole.jsx
+++ b/src/components/DebugConsole.jsx
@@ -1,0 +1,117 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import { MATERIALS, RECIPES } from '../constants';
+
+const DebugConsole = ({ gameState, setGameState, resetGame, openShop, serveCustomer }) => {
+  const [goldAmount, setGoldAmount] = useState('');
+  const [materialId, setMaterialId] = useState(Object.keys(MATERIALS)[0]);
+  const [materialAmount, setMaterialAmount] = useState('1');
+  const [darkMode, setDarkMode] = useState(() =>
+    document.documentElement.classList.contains('dark')
+  );
+
+  const toggleDarkMode = () => {
+    const root = document.documentElement;
+    if (root.classList.contains('dark')) {
+      root.classList.remove('dark');
+      setDarkMode(false);
+    } else {
+      root.classList.add('dark');
+      setDarkMode(true);
+    }
+  };
+
+  const addGold = () => {
+    const amount = parseInt(goldAmount, 10) || 0;
+    if (!amount) return;
+    setGameState(prev => ({ ...prev, gold: prev.gold + amount }));
+    setGoldAmount('');
+  };
+
+  const addMaterial = () => {
+    const amount = parseInt(materialAmount, 10) || 0;
+    if (!amount) return;
+    setGameState(prev => ({
+      ...prev,
+      materials: {
+        ...prev.materials,
+        [materialId]: (prev.materials[materialId] || 0) + amount,
+      },
+    }));
+  };
+
+  const simulateSale = () => {
+    const customer = gameState.customers.find(c => !c.satisfied);
+    if (!customer) return;
+    const match = Object.entries(gameState.inventory).find(([id, count]) => {
+      if (count < 1) return false;
+      const recipe = RECIPES.find(r => r.id === id);
+      return recipe && recipe.type === customer.requestType;
+    });
+    if (match) {
+      serveCustomer(customer.id, match[0]);
+    }
+  };
+
+  return (
+    <div className="fixed bottom-16 right-4 bg-white border border-gray-300 rounded-lg shadow-lg p-4 w-72 z-50 text-sm space-y-3">
+      <h2 className="font-bold mb-2">Debug Console</h2>
+      <button className="w-full bg-red-500 hover:bg-red-600 text-white rounded p-1" onClick={resetGame}>
+        Reset Game
+      </button>
+      <button className="w-full bg-gray-500 hover:bg-gray-600 text-white rounded p-1" onClick={toggleDarkMode}>
+        Toggle {darkMode ? 'Light' : 'Dark'} Mode
+      </button>
+      <div className="flex gap-2 items-center">
+        <input
+          type="number"
+          className="border p-1 flex-1"
+          placeholder="Gold"
+          value={goldAmount}
+          onChange={e => setGoldAmount(e.target.value)}
+        />
+        <button className="bg-yellow-500 hover:bg-yellow-600 text-white px-2 py-1 rounded" onClick={addGold}>
+          Add
+        </button>
+      </div>
+      <div className="flex gap-2 items-center">
+        <select
+          className="border p-1 flex-1"
+          value={materialId}
+          onChange={e => setMaterialId(e.target.value)}
+        >
+          {Object.entries(MATERIALS).map(([id, m]) => (
+            <option key={id} value={id}>
+              {m.name}
+            </option>
+          ))}
+        </select>
+        <input
+          type="number"
+          className="border p-1 w-16"
+          value={materialAmount}
+          onChange={e => setMaterialAmount(e.target.value)}
+        />
+        <button className="bg-green-500 hover:bg-green-600 text-white px-2 py-1 rounded" onClick={addMaterial}>
+          Add
+        </button>
+      </div>
+      <button className="w-full bg-blue-500 hover:bg-blue-600 text-white rounded p-1" onClick={openShop}>
+        Open Shop
+      </button>
+      <button className="w-full bg-purple-500 hover:bg-purple-600 text-white rounded p-1" onClick={simulateSale}>
+        Simulate Sale
+      </button>
+    </div>
+  );
+};
+
+DebugConsole.propTypes = {
+  gameState: PropTypes.object.isRequired,
+  setGameState: PropTypes.func.isRequired,
+  resetGame: PropTypes.func.isRequired,
+  openShop: PropTypes.func.isRequired,
+  serveCustomer: PropTypes.func.isRequired,
+};
+
+export default DebugConsole;

--- a/src/features/__tests__/MaterialStallsPanel.test.jsx
+++ b/src/features/__tests__/MaterialStallsPanel.test.jsx
@@ -5,6 +5,6 @@ describe('MaterialStallsPanel', () => {
   test('renders material chips', () => {
     const gameState = { materials: { wood: 2 } };
     render(<MaterialStallsPanel gameState={gameState} />);
-    expect(screen.getByText(/wood/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/wood/i).length).toBeGreaterThan(0);
   });
 });


### PR DESCRIPTION
## Summary
- add DebugConsole component to tweak game state during testing
- integrate debug toggle into main app when not in production
- update MaterialStallsPanel test for duplicate text

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_689a34cd235083209f1c377bc4c83aa3