### PR TITLE
Ensure debug tools are visible above bottom navigation

### DIFF
--- a/src/components/BottomNavigation.jsx
+++ b/src/components/BottomNavigation.jsx
@@ -10,7 +10,7 @@ const BottomNavigation = ({ currentTab, onTabChange }) => {
   ];
 
   return (
-    <nav className="fixed bottom-0 left-0 right-0 bg-white border-t border-gray-200 grid grid-cols-4 shadow-lg z-50 safe-area-bottom">
+    <nav className="fixed bottom-0 left-0 right-0 bg-white border-t border-gray-200 grid grid-cols-4 shadow-lg z-30 safe-area-bottom">
       {tabs.map(tab => (
         <button
           key={tab.id}

--- a/src/components/EventLog.jsx
+++ b/src/components/EventLog.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const EventLog = ({ events }) => (
-  <div className="bg-gray-50 border rounded p-2 max-h-40 overflow-y-auto">
+  <div className="fixed bottom-24 left-4 right-4 z-40 max-w-md mx-auto bg-gray-50 border rounded p-2 max-h-40 overflow-y-auto">
     {events.length === 0 ? (
       <p className="text-gray-500 italic text-center py-8 text-sm sm:text-xs">No events yet...</p>
     ) : (


### PR DESCRIPTION
## Summary
- Lower bottom navigation z-index to avoid covering overlays
- Position event log above nav with fixed layout

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_689a5e0f68448320a6985f63e3110dac