### PR TITLE
Prevent bottom nav from hiding debug tools and event log

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -152,7 +152,7 @@ const MerchantsMorning = () => {
       {process.env.NODE_ENV !== 'production' && (
         <>
           <button
-            className="fixed bottom-20 right-4 bg-gray-700 text-white px-3 py-1 rounded z-50"
+            className="fixed bottom-32 right-4 bg-gray-700 text-white px-3 py-1 rounded z-50"
             onClick={() => setShowDebug(prev => !prev)}
           >
             {showDebug ? 'Close Debug' : 'Debug'}

--- a/src/components/BottomNavigation.jsx
+++ b/src/components/BottomNavigation.jsx
@@ -10,7 +10,7 @@ const BottomNavigation = ({ currentTab, onTabChange }) => {
   ];
 
   return (
-    <nav className="fixed bottom-0 left-0 right-0 bg-white border-t border-gray-200 grid grid-cols-4 shadow-lg z-50 safe-area-bottom">
+    <nav className="fixed bottom-0 left-0 right-0 bg-white border-t border-gray-200 grid grid-cols-4 shadow-lg z-40 safe-area-bottom">
       {tabs.map(tab => (
         <button
           key={tab.id}

--- a/src/components/DebugConsole.jsx
+++ b/src/components/DebugConsole.jsx
@@ -54,7 +54,7 @@ const DebugConsole = ({ gameState, setGameState, resetGame, openShop, serveCusto
   };
 
   return (
-    <div className="fixed bottom-24 right-4 bg-white border border-gray-300 rounded-lg shadow-lg p-4 w-72 z-50 text-sm space-y-3">
+    <div className="fixed bottom-32 right-4 bg-white border border-gray-300 rounded-lg shadow-lg p-4 w-72 z-50 text-sm space-y-3">
       <h2 className="font-bold mb-2">Debug Console</h2>
       <button className="w-full bg-red-500 hover:bg-red-600 text-white rounded p-1" onClick={resetGame}>
         Reset Game

--- a/src/components/EventLog.jsx
+++ b/src/components/EventLog.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const EventLog = ({ events }) => (
-  <div className="bg-gray-50 border rounded p-2 max-h-40 overflow-y-auto">
+  <div className="fixed bottom-24 left-4 right-4 bg-gray-50 border rounded p-2 max-h-40 overflow-y-auto shadow-lg z-50 safe-area-bottom">
     {events.length === 0 ? (
       <p className="text-gray-500 italic text-center py-8 text-sm sm:text-xs">No events yet...</p>
     ) : (


### PR DESCRIPTION
## Summary
- Lower bottom nav z-index so overlays can sit above it
- Make EventLog a fixed panel positioned above the nav
- Move debug toggle and console higher to avoid overlap

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_689a5e0f68448320a6985f63e3110dac